### PR TITLE
Features/new source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ chroma_db_persistence/
 
 # Logs
 *.log
+dry_run_logs/
 
 # OS metadata
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ chroma_db_persistence/
 *.log
 dry_run_logs/
 
+# Runtime state
+seen_cache.json
+seen_cache.json.tmp
+
 # OS metadata
 .DS_Store
 Thumbs.db

--- a/Redme-Oracle.md
+++ b/Redme-Oracle.md
@@ -45,7 +45,10 @@ NEWS_URL=...
 GEMINI_API_KEY=...
 SUPABASE_URL=...
 SUPABASE_KEY=...
-COHERE_API_KEY=...
+# Optional:
+# GEMINI_MODEL=gemini-2.5-flash-lite
+# GEMINI_MIN_CALL_INTERVAL_SEC=6.5
+# LOG_LEVEL=INFO
 ```
 
 Save with `Ctrl+X` → `Y` → `Enter`.
@@ -74,13 +77,19 @@ Paste the following (replace `YOUR_REPO` with your actual folder name):
 [Unit]
 Description=News Bot
 After=network.target
+# Stop restart-looping if the bot crashes 5 times within 10 minutes
+# (e.g. a missing .env variable raises at startup)
+StartLimitIntervalSec=600
+StartLimitBurst=5
 
 [Service]
 User=ubuntu
 WorkingDirectory=/home/ubuntu/YOUR_REPO
 ExecStart=/home/ubuntu/YOUR_REPO/.venv/bin/python main.py
-Restart=always
-RestartSec=10
+Restart=on-failure
+RestartSec=30
+# Keep a runaway process from eating the Always Free instance's RAM
+MemoryMax=512M
 
 [Install]
 WantedBy=multi-user.target

--- a/Redme-Oracle.md
+++ b/Redme-Oracle.md
@@ -1,0 +1,152 @@
+# Oracle Cloud VPS Setup — Ubuntu 24.04 Minimal
+
+## Initial Setup
+
+### 1. Connect to your VM
+
+```bash
+ssh -i "D:\Private dock\Scans\Keys\Oracle\PythonAI\ssh-key-2026-05-16.key" ubuntu@YOUR_PUBLIC_IP
+```
+
+### 2. Update system & install dependencies
+
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install python3 python3-pip python3-venv git -y
+```
+
+### 3. Clone your repo
+
+```bash
+git clone https://github.com/YOUR_USERNAME/YOUR_REPO.git
+cd YOUR_REPO
+```
+
+### 4. Create virtualenv & install packages
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 5. Create `.env` file with credentials
+
+```bash
+nano .env
+```
+
+Paste all your credentials:
+
+```env
+BOT_TOKEN=...
+CHAT_ID=...
+NEWS_URL=...
+GEMINI_API_KEY=...
+SUPABASE_URL=...
+SUPABASE_KEY=...
+COHERE_API_KEY=...
+```
+
+Save with `Ctrl+X` → `Y` → `Enter`.
+
+### 6. Test the bot runs
+
+```bash
+python3 main.py --dry-run
+```
+
+If no errors, stop it with `Ctrl+C` and proceed.
+
+---
+
+## Running as a System Service
+
+### 7. Create systemd service
+
+```bash
+sudo nano /etc/systemd/system/newsbot.service
+```
+
+Paste the following (replace `YOUR_REPO` with your actual folder name):
+
+```ini
+[Unit]
+Description=News Bot
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/home/ubuntu/YOUR_REPO
+ExecStart=/home/ubuntu/YOUR_REPO/.venv/bin/python main.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Save with `Ctrl+X` → `Y` → `Enter`.
+
+### 8. Enable & start the service
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable newsbot
+sudo systemctl start newsbot
+sudo systemctl status newsbot
+```
+
+You should see `Active: active (running)`.
+
+### 9. Monitor live logs
+
+```bash
+journalctl -u newsbot -f
+```
+
+The bot now runs 24/7, auto-starts on reboot, and auto-restarts on crash.
+
+---
+
+## Stopping & Updating the Bot
+
+### Stop the service
+
+```bash
+sudo systemctl stop newsbot
+```
+
+### Make your code changes
+
+**Option A — Pull latest from Git:**
+
+```bash
+cd ~/YOUR_REPO
+git pull
+```
+
+**Option B — Edit a file directly:**
+
+```bash
+nano main.py
+```
+
+**Option C — Reinstall dependencies** (if `requirements.txt` changed):
+
+```bash
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Restart the service
+
+```bash
+sudo systemctl start newsbot
+```
+
+### Verify it's running
+
+```bash
+sudo systemctl status newsbot
+```

--- a/ai/ai_prompts.py
+++ b/ai/ai_prompts.py
@@ -1,27 +1,81 @@
-def get_summarize_with_emojis_prompt(target_language='en'):
-    """
-    Returns the system prompt for summarizing an article with emojis.
-    """
-    if target_language.lower() == 'en':
-        lang = 'English B2 level'
-    elif target_language.lower() == 'es':
-        lang = 'Spanish'
-    elif target_language.lower() == 'ru':
-        lang = 'Russian'
-    else:
-        lang = 'English'
+_LANG_NAMES = {
+    'es': 'Spanish',
+    'en': 'English',
+    'fr': 'French',
+    'de': 'German',
+    'ru': 'Russian',
+    'pt': 'Portuguese',
+}
 
+def _lang_name(code):
+    return _LANG_NAMES.get(code.lower(), code)
+
+
+# Provider-agnostic JSON Schema for article evaluation.
+# Each provider wraps this in its own request-format envelope.
+EVALUATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "expat_impact": {"type": "integer", "minimum": 1, "maximum": 10, "description": "How relevant or impactful the news is for expatriates (1-10)"},
+        "event_weight": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Significance or uniqueness of the event (1-10)"},
+        "politics": {"type": "integer", "minimum": 0, "maximum": 10, "description": "Non-political/innovation score (0=political, 10=non-political/innovative)"},
+        "timeliness": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Time-sensitivity or urgency (1-10)"},
+        "practical_utility": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Usefulness for reader's daily life (1-10)"},
+    },
+    "required": ["expat_impact", "event_weight", "politics", "timeliness", "practical_utility"],
+    "additionalProperties": False,
+}
+
+
+def get_summarize_with_emojis_prompt(target_language='en', source_language='es'):
+    target_map = {'en': 'English B2 level', 'es': 'Spanish', 'ru': 'Russian'}
+    target_lang = target_map.get(target_language.lower(), 'English')
+    source_lang = _lang_name(source_language)
     return (
-        "You are a helpful assistant. Summarize with details the following Spanish news article "
-        f"in 3-4 sentences in {lang} with a slightly sarcastic or humorous style where it appropriate. "
+        f"You are a helpful assistant. Summarize with details the following {source_lang} news article "
+        f"in 3-4 sentences in {target_lang} with a slightly sarcastic or humorous style where it appropriate. "
         "End the summary with 1-3 emojis that match the tone of the news."
     )
 
-def get_evaluate_article_prompt():
-    """
-    Returns the system prompt for evaluating an article.
-    """
+
+_EVALUATE_FEW_SHOT = """
+Score each dimension 1-10 (politics is 0-10). Use these anchors:
+- expat_impact: 1=only matters to native Spaniards (regional pension reform); 5=general interest; 10=directly affects expats (visas, flights, English services, foreign communities).
+- event_weight: 1=routine bureaucracy; 5=notable local event; 10=rare or city-defining (major opening, disaster, milestone).
+- politics: 0=pure party politics with no public-service angle; 5=policy with concrete citizen impact; 10=apolitical (innovation, science, culture, weather).
+- timeliness: 1=evergreen; 5=this week; 10=happening now, action required today.
+- practical_utility: 1=trivia; 5=nice to know; 10=changes what reader does today (closure, deadline, opportunity).
+
+Examples:
+
+<example>
+<article>
+Ryanair anuncia una nueva ruta directa entre el aeropuerto de Malaga-Costa del Sol y Berlin, con cuatro vuelos semanales a partir del 28 de octubre. Los billetes saldran a la venta esta semana desde 24,99 euros.
+</article>
+<output>{"expat_impact": 9, "event_weight": 7, "politics": 10, "timeliness": 8, "practical_utility": 9}</output>
+</example>
+
+<example>
+<article>
+El PP de Malaga acusa al PSOE de "bloquear" la comision municipal de hacienda tras la ausencia de tres concejales socialistas en la sesion del martes. El portavoz socialista ha respondido calificando las declaraciones de "cortina de humo".
+</article>
+<output>{"expat_impact": 2, "event_weight": 2, "politics": 1, "timeliness": 4, "practical_utility": 1}</output>
+</example>
+
+<example>
+<article>
+La AEMET activa el aviso naranja por lluvias torrenciales en la provincia de Malaga para este jueves, con acumulados que podrian superar los 80 litros por metro cuadrado en cuatro horas. El 112 recomienda evitar desplazamientos no esenciales y los ayuntamientos de la costa cierran parques y playas.
+</article>
+<output>{"expat_impact": 8, "event_weight": 6, "politics": 10, "timeliness": 10, "practical_utility": 10}</output>
+</example>
+""".strip()
+
+
+def get_evaluate_article_prompt(source_language='es'):
+    source_lang = _lang_name(source_language)
     return (
-        "You are a news evaluation agent. Your role is to score local news stories based on how likely they are to interest a general audience, "
-        "especially international readers and expats in Malaga. "
+        "You are a news evaluation agent. Your role is to score local news stories based on how likely they are to interest "
+        f"a general audience, especially international readers and expats in Malaga. The article is written in {source_lang}.\n\n"
+        f"{_EVALUATE_FEW_SHOT}\n\n"
+        "Now score the article that follows. Return ONLY the JSON object - no commentary, no markdown."
     )

--- a/ai/ai_prompts.py
+++ b/ai/ai_prompts.py
@@ -11,7 +11,16 @@ def _lang_name(code):
     return _LANG_NAMES.get(code.lower(), code)
 
 
-# Provider-agnostic JSON Schema for article evaluation.
+_TARGET_LANG_STYLES = {
+    'en': 'English at B2 level',
+    'es': 'Spanish',
+    'ru': 'Russian',
+}
+
+# Provider-agnostic JSON Schema for the combined evaluate + summarize call.
+# One LLM request per article instead of two — on the free tier the binding
+# constraint is requests per day, not tokens, so the always-generated summary
+# (discarded for below-threshold articles) is the cheaper side of the trade.
 # Each provider wraps this in its own request-format envelope.
 EVALUATION_SCHEMA = {
     "type": "object",
@@ -21,21 +30,11 @@ EVALUATION_SCHEMA = {
         "politics": {"type": "integer", "minimum": 0, "maximum": 10, "description": "Non-political/innovation score (0=political, 10=non-political/innovative)"},
         "timeliness": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Time-sensitivity or urgency (1-10)"},
         "practical_utility": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Usefulness for reader's daily life (1-10)"},
+        "summary": {"type": "string", "description": "3-4 sentence summary in the target language, slightly sarcastic or humorous where appropriate, ending with 1-3 emojis matching the tone"},
     },
-    "required": ["expat_impact", "event_weight", "politics", "timeliness", "practical_utility"],
+    "required": ["expat_impact", "event_weight", "politics", "timeliness", "practical_utility", "summary"],
     "additionalProperties": False,
 }
-
-
-def get_summarize_with_emojis_prompt(target_language='en', source_language='es'):
-    target_map = {'en': 'English B2 level', 'es': 'Spanish', 'ru': 'Russian'}
-    target_lang = target_map.get(target_language.lower(), 'English')
-    source_lang = _lang_name(source_language)
-    return (
-        f"You are a helpful assistant. Summarize with details the following {source_lang} news article "
-        f"in 3-4 sentences in {target_lang} with a slightly sarcastic or humorous style where it appropriate. "
-        "End the summary with 1-3 emojis that match the tone of the news."
-    )
 
 
 _EVALUATE_FEW_SHOT = """
@@ -52,30 +51,33 @@ Examples:
 <article>
 Ryanair anuncia una nueva ruta directa entre el aeropuerto de Malaga-Costa del Sol y Berlin, con cuatro vuelos semanales a partir del 28 de octubre. Los billetes saldran a la venta esta semana desde 24,99 euros.
 </article>
-<output>{"expat_impact": 9, "event_weight": 7, "politics": 10, "timeliness": 8, "practical_utility": 9}</output>
+<output>{"expat_impact": 9, "event_weight": 7, "politics": 10, "timeliness": 8, "practical_utility": 9, "summary": "Ryanair is launching a direct Malaga-Berlin route with four weekly flights from 28 October. Tickets go on sale this week from a wallet-friendly 24.99 euros, so your excuses for skipping that Berlin weekend are officially gone. ✈️🇩🇪"}</output>
 </example>
 
 <example>
 <article>
 El PP de Malaga acusa al PSOE de "bloquear" la comision municipal de hacienda tras la ausencia de tres concejales socialistas en la sesion del martes. El portavoz socialista ha respondido calificando las declaraciones de "cortina de humo".
 </article>
-<output>{"expat_impact": 2, "event_weight": 2, "politics": 1, "timeliness": 4, "practical_utility": 1}</output>
+<output>{"expat_impact": 2, "event_weight": 2, "politics": 1, "timeliness": 4, "practical_utility": 1, "summary": "Malaga's PP accuses the PSOE of blocking the municipal finance committee after three socialist councillors skipped Tuesday's session. The socialists call it all a smoke screen — in other words, a perfectly ordinary day in local politics. 🎭"}</output>
 </example>
 
 <example>
 <article>
 La AEMET activa el aviso naranja por lluvias torrenciales en la provincia de Malaga para este jueves, con acumulados que podrian superar los 80 litros por metro cuadrado en cuatro horas. El 112 recomienda evitar desplazamientos no esenciales y los ayuntamientos de la costa cierran parques y playas.
 </article>
-<output>{"expat_impact": 8, "event_weight": 6, "politics": 10, "timeliness": 10, "practical_utility": 10}</output>
+<output>{"expat_impact": 8, "event_weight": 6, "politics": 10, "timeliness": 10, "practical_utility": 10, "summary": "AEMET has issued an orange alert for torrential rain in Malaga province this Thursday, with up to 80 litres per square metre possible in just four hours. Emergency services advise skipping non-essential trips, and coastal towns are closing parks and beaches — a good day to admire the weather from your sofa. 🌧️⚠️"}</output>
 </example>
 """.strip()
 
 
-def get_evaluate_article_prompt(source_language='es'):
+def get_evaluate_and_summarize_prompt(source_language='es', target_language='en'):
     source_lang = _lang_name(source_language)
+    target_lang = _TARGET_LANG_STYLES.get(target_language.lower(), 'English')
     return (
         "You are a news evaluation agent. Your role is to score local news stories based on how likely they are to interest "
-        f"a general audience, especially international readers and expats in Malaga. The article is written in {source_lang}.\n\n"
+        f"a general audience, especially international readers and expats in Malaga, and to summarize them. The article is written in {source_lang}.\n\n"
+        f"In the \"summary\" field, summarize the article with details in 3-4 sentences in {target_lang}, "
+        "with a slightly sarcastic or humorous style where appropriate. End the summary with 1-3 emojis that match the tone of the news.\n\n"
         f"{_EVALUATE_FEW_SHOT}\n\n"
-        "Now score the article that follows. Return ONLY the JSON object - no commentary, no markdown."
+        "Now score and summarize the article that follows. Return ONLY the JSON object - no commentary, no markdown."
     )

--- a/ai/base_ai_service.py
+++ b/ai/base_ai_service.py
@@ -20,28 +20,19 @@ class BaseAIService(ABC):
     """
 
     @abstractmethod
-    def summarize_with_emojis(self, article_text, target_language='en', source_language='es') -> str:
+    def evaluate_and_summarize(self, article_text, source_language='es', target_language='en') -> Optional[Dict[str, Any]]:
         """
-        Summarizes the given article text with emojis.
+        Scores and summarizes the article in a single LLM call (one request per
+        article instead of two — requests, not tokens, are the scarce resource
+        on free tiers).
 
-        :param article_text: The text of the article to summarize.
+        :param article_text: The text of the article to process.
+        :param source_language: The language the article is written in (ISO 639-1 code).
         :param target_language: The target language for the summary.
-        :param source_language: The language the article is written in (ISO 639-1 code).
-        :return: The summarized text with emojis.
-        """
-        ...
-
-    @abstractmethod
-    def evaluate_article(self, article_text, source_language='es') -> Dict[str, Any]:
-        """
-        Evaluates the article based on predefined criteria.
-
-        :param article_text: The text of the article to evaluate.
-        :param source_language: The language the article is written in (ISO 639-1 code).
-        :return: {'score': float, 'breakdown': dict|None}. Bot logic uses `score`
-                 (averaged); `breakdown` exposes per-dimension integers
+        :return: {'score': float, 'breakdown': dict, 'summary': str} where
+                 `score` is the mean of the five per-dimension integers
                  (expat_impact, event_weight, politics, timeliness,
-                 practical_utility) for dry-run analysis. `breakdown` is None
-                 when the response failed to parse.
+                 practical_utility) and `summary` is the emoji-rich Telegram
+                 text. None when the response failed to parse.
         """
         ...

--- a/ai/base_ai_service.py
+++ b/ai/base_ai_service.py
@@ -1,4 +1,17 @@
 from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+class RateLimitError(Exception):
+    """Raised when an AI provider returns a rate-limit / quota error.
+
+    ``retry_after`` is the seconds the provider asked us to wait, when known.
+    """
+
+    def __init__(self, message: str, retry_after: Optional[float] = None):
+        super().__init__(message)
+        self.retry_after = retry_after
+
 
 class BaseAIService(ABC):
     """
@@ -7,22 +20,28 @@ class BaseAIService(ABC):
     """
 
     @abstractmethod
-    def summarize_with_emojis(self, article_text, target_language='en'):
+    def summarize_with_emojis(self, article_text, target_language='en', source_language='es') -> str:
         """
         Summarizes the given article text with emojis.
 
         :param article_text: The text of the article to summarize.
         :param target_language: The target language for the summary.
+        :param source_language: The language the article is written in (ISO 639-1 code).
         :return: The summarized text with emojis.
         """
-        pass
+        ...
 
     @abstractmethod
-    def evaluate_article(self, article_text):
+    def evaluate_article(self, article_text, source_language='es') -> Dict[str, Any]:
         """
         Evaluates the article based on predefined criteria.
 
         :param article_text: The text of the article to evaluate.
-        :return: The evaluation score for the article.
+        :param source_language: The language the article is written in (ISO 639-1 code).
+        :return: {'score': float, 'breakdown': dict|None}. Bot logic uses `score`
+                 (averaged); `breakdown` exposes per-dimension integers
+                 (expat_impact, event_weight, politics, timeliness,
+                 practical_utility) for dry-run analysis. `breakdown` is None
+                 when the response failed to parse.
         """
-        pass
+        ...

--- a/ai/gemini_service.py
+++ b/ai/gemini_service.py
@@ -14,17 +14,18 @@ _MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash-lite")
 _API_URL = f"https://generativelanguage.googleapis.com/v1beta/models/{_MODEL}:generateContent"
 
 # Provider-specific sampling — kept here so other providers stay independent.
-_TEMPERATURE_EVALUATE = 0.2
-_TEMPERATURE_SUMMARIZE = 0.7
-_MAX_OUTPUT_TOKENS_EVALUATE = 256
-_MAX_OUTPUT_TOKENS_SUMMARIZE = 512
+# Single combined call: low enough for stable integer scores, high enough
+# that the summary doesn't read like a police report.
+_TEMPERATURE = 0.4
+_MAX_OUTPUT_TOKENS = 1024
 
 # Free-tier RPM caps: flash=10, flash-lite=15. 6.5s spacing keeps us safely under 10 RPM.
 _MIN_CALL_INTERVAL_SEC = float(os.getenv("GEMINI_MIN_CALL_INTERVAL_SEC", "6.5"))
 
-# Gemini's responseSchema is a subset of OpenAPI 3.0 — it rejects JSON-Schema-only
-# keywords (additionalProperties, minimum, maximum) and expects Type values in
-# uppercase form (OBJECT, INTEGER, ...).
+# Legacy fallback only: Gemini's responseSchema is a subset of OpenAPI 3.0 — it
+# rejects JSON-Schema-only keywords (additionalProperties, minimum, maximum)
+# and expects Type values in uppercase form (OBJECT, INTEGER, ...). The primary
+# path uses responseJsonSchema, which accepts standard JSON Schema as-is.
 _GEMINI_SCHEMA_ALLOWED = {
     "type", "format", "description", "nullable", "enum",
     "maxItems", "minItems", "properties", "required",
@@ -91,6 +92,10 @@ def _parse_retry_after(resp):
 class GeminiService(BaseAIService):
     _last_call_at = 0.0
     _stagger_lock = threading.Lock()
+    # Flips to True (process-wide) if the API rejects responseJsonSchema,
+    # e.g. an older API surface — subsequent calls go straight to the
+    # sanitized legacy responseSchema format.
+    _use_legacy_schema = False
 
     def __init__(self, api_key):
         self.api_key = api_key
@@ -104,6 +109,11 @@ class GeminiService(BaseAIService):
                 time.sleep(wait)
             GeminiService._last_call_at = time.monotonic()
 
+    def _schema_config(self, response_schema):
+        if GeminiService._use_legacy_schema:
+            return {"responseSchema": _sanitize_schema(response_schema)}
+        return {"responseJsonSchema": response_schema}
+
     def _generate(self, system_prompt, user_content, *, temperature, max_output_tokens, response_schema=None):
         self._stagger()
         generation_config = {
@@ -115,7 +125,7 @@ class GeminiService(BaseAIService):
         }
         if response_schema is not None:
             generation_config["responseMimeType"] = "application/json"
-            generation_config["responseSchema"] = _sanitize_schema(response_schema)
+            generation_config.update(self._schema_config(response_schema))
 
         body = {
             "systemInstruction": {"parts": [{"text": system_prompt}]},
@@ -128,6 +138,19 @@ class GeminiService(BaseAIService):
             raise GeminiRateLimitError(
                 f"429 Too Many Requests for {_MODEL} (retry_after={retry_after})",
                 retry_after=retry_after,
+            )
+        if (
+            resp.status_code == 400
+            and response_schema is not None
+            and not GeminiService._use_legacy_schema
+            and "responseJsonSchema" in resp.text
+        ):
+            logger.warning("Gemini rejected responseJsonSchema — falling back to legacy responseSchema for this process.")
+            GeminiService._use_legacy_schema = True
+            return self._generate(
+                system_prompt, user_content,
+                temperature=temperature, max_output_tokens=max_output_tokens,
+                response_schema=response_schema,
             )
         if not resp.ok:
             raise RuntimeError(f"Gemini HTTP {resp.status_code}: {resp.text}")
@@ -149,24 +172,14 @@ class GeminiService(BaseAIService):
             raise RuntimeError("Gemini returned empty text")
         return text
 
-    def summarize_with_emojis(self, article_text, target_language='en', source_language='es'):
-        system_prompt = ai_prompts.get_summarize_with_emojis_prompt(target_language, source_language)
+    def evaluate_and_summarize(self, article_text, source_language='es', target_language='en'):
+        system_prompt = ai_prompts.get_evaluate_and_summarize_prompt(source_language, target_language)
         text = self._generate(
             system_prompt,
             _wrap_article(article_text),
-            temperature=_TEMPERATURE_SUMMARIZE,
-            max_output_tokens=_MAX_OUTPUT_TOKENS_SUMMARIZE,
-        )
-        return response_parser.parse_summary_with_emojis(text)
-
-    def evaluate_article(self, article_text, source_language='es'):
-        system_prompt = ai_prompts.get_evaluate_article_prompt(source_language)
-        text = self._generate(
-            system_prompt,
-            _wrap_article(article_text),
-            temperature=_TEMPERATURE_EVALUATE,
-            max_output_tokens=_MAX_OUTPUT_TOKENS_EVALUATE,
+            temperature=_TEMPERATURE,
+            max_output_tokens=_MAX_OUTPUT_TOKENS,
             response_schema=ai_prompts.EVALUATION_SCHEMA,
         )
         logger.debug(f"Gemini evaluate response: {text}")
-        return response_parser.parse_evaluate_article(text)
+        return response_parser.parse_evaluate_and_summarize(text)

--- a/ai/gemini_service.py
+++ b/ai/gemini_service.py
@@ -1,7 +1,7 @@
 import os
 import logging
 import requests
-from ai.base_ai_service import BaseAIService
+from ai.base_ai_service import BaseAIService, RateLimitError
 import ai.ai_prompts as ai_prompts
 import response_parser
 
@@ -10,17 +10,92 @@ logger = logging.getLogger(__name__)
 _MODEL = os.getenv("GEMINI_MODEL", "gemini-2.5-flash")
 _API_URL = f"https://generativelanguage.googleapis.com/v1beta/models/{_MODEL}:generateContent"
 
+# Provider-specific sampling — kept here so other providers stay independent.
+_TEMPERATURE_EVALUATE = 0.2
+_TEMPERATURE_SUMMARIZE = 0.7
+_MAX_OUTPUT_TOKENS_EVALUATE = 256
+_MAX_OUTPUT_TOKENS_SUMMARIZE = 512
+
+# Gemini's responseSchema is a subset of OpenAPI 3.0 — it rejects JSON-Schema-only
+# keywords (additionalProperties, minimum, maximum) and expects Type values in
+# uppercase form (OBJECT, INTEGER, ...).
+_GEMINI_SCHEMA_ALLOWED = {
+    "type", "format", "description", "nullable", "enum",
+    "maxItems", "minItems", "properties", "required",
+    "propertyOrdering", "items",
+}
+
+
+def _sanitize_schema(schema):
+    if isinstance(schema, dict):
+        out = {}
+        for k, v in schema.items():
+            if k not in _GEMINI_SCHEMA_ALLOWED:
+                continue
+            if k == "type" and isinstance(v, str):
+                out[k] = v.upper()
+            elif k == "properties" and isinstance(v, dict):
+                # Keys here are user-defined property names, not schema keywords —
+                # keep them verbatim and only sanitize the nested schema values.
+                out[k] = {pname: _sanitize_schema(pschema) for pname, pschema in v.items()}
+            else:
+                out[k] = _sanitize_schema(v)
+        return out
+    if isinstance(schema, list):
+        return [_sanitize_schema(v) for v in schema]
+    return schema
+
+
+def _wrap_article(article_text):
+    return f"<article>\n{article_text}\n</article>"
+
+
+def _parse_retry_delay(payload):
+    """Extract retryDelay seconds from a Gemini error payload's RetryInfo detail."""
+    details = ((payload or {}).get("error") or {}).get("details") or []
+    for detail in details:
+        if detail.get("@type", "").endswith("/google.rpc.RetryInfo"):
+            delay = detail.get("retryDelay", "")
+            if isinstance(delay, str) and delay.endswith("s"):
+                try:
+                    return float(delay[:-1])
+                except ValueError:
+                    return None
+    return None
+
 
 class GeminiService(BaseAIService):
     def __init__(self, api_key):
         self.api_key = api_key
 
-    def _generate(self, prompt, json_mode=False):
-        body = {"contents": [{"parts": [{"text": prompt}]}]}
-        if json_mode:
-            body["generationConfig"] = {"responseMimeType": "application/json"}
+    def _generate(self, system_prompt, user_content, *, temperature, max_output_tokens, response_schema=None):
+        generation_config = {
+            "temperature": temperature,
+            "maxOutputTokens": max_output_tokens,
+            # Gemini 2.5 models enable "thinking" by default and charge thought
+            # tokens against maxOutputTokens, which can starve the visible reply.
+            "thinkingConfig": {"thinkingBudget": 0},
+        }
+        if response_schema is not None:
+            generation_config["responseMimeType"] = "application/json"
+            generation_config["responseSchema"] = _sanitize_schema(response_schema)
+
+        body = {
+            "systemInstruction": {"parts": [{"text": system_prompt}]},
+            "contents": [{"parts": [{"text": user_content}]}],
+            "generationConfig": generation_config,
+        }
         resp = requests.post(f"{_API_URL}?key={self.api_key}", json=body, timeout=60)
-        resp.raise_for_status()
+        if not resp.ok:
+            if resp.status_code == 429:
+                try:
+                    payload = resp.json()
+                except ValueError:
+                    payload = None
+                retry_after = _parse_retry_delay(payload)
+                suffix = f", retry in {retry_after:.0f}s" if retry_after else ""
+                raise RateLimitError(f"Gemini rate limit (429){suffix}", retry_after=retry_after)
+            raise RuntimeError(f"Gemini HTTP {resp.status_code}: {resp.text}")
         data = resp.json()
 
         candidates = data.get("candidates") or []
@@ -39,32 +114,24 @@ class GeminiService(BaseAIService):
             raise RuntimeError("Gemini returned empty text")
         return text
 
-    def summarize_with_emojis(self, article_text, target_language='en'):
-        prompt = ai_prompts.get_summarize_with_emojis_prompt(target_language)
-        text = self._generate(f"{prompt}\n\n{article_text}")
+    def summarize_with_emojis(self, article_text, target_language='en', source_language='es'):
+        system_prompt = ai_prompts.get_summarize_with_emojis_prompt(target_language, source_language)
+        text = self._generate(
+            system_prompt,
+            _wrap_article(article_text),
+            temperature=_TEMPERATURE_SUMMARIZE,
+            max_output_tokens=_MAX_OUTPUT_TOKENS_SUMMARIZE,
+        )
         return response_parser.parse_summary_with_emojis(text)
 
-    def evaluate_article(self, article_text):
-        prompt = ai_prompts.get_evaluate_article_prompt()
-        response_format = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": "article_evaluation",
-                "schema": {
-                    "type": "object",
-                    "properties": {
-                        "expat_impact": {"type": "integer", "minimum": 1, "maximum": 10, "description": "How relevant or impactful the news is for expatriates (1-10)"},
-                        "event_weight": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Significance or uniqueness of the event (1-10)"},
-                        "politics": {"type": "integer", "minimum": 0, "maximum": 10, "description": "Non-political/innovation score (0=political, 10=non-political/innovative)"},
-                        "timeliness": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Time-sensitivity or urgency (1-10)"},
-                        "practical_utility": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Usefulness for reader's daily life (1-10)"}
-                    },
-                    "required": ["expat_impact", "event_weight", "politics", "timeliness", "practical_utility"],
-                    "additionalProperties": False
-                }
-            }
-        }
-        full_prompt = f"{prompt} Provide a JSON response with the following schema: {response_format}\n\n{article_text}"
-        text = self._generate(full_prompt, json_mode=True)
+    def evaluate_article(self, article_text, source_language='es'):
+        system_prompt = ai_prompts.get_evaluate_article_prompt(source_language)
+        text = self._generate(
+            system_prompt,
+            _wrap_article(article_text),
+            temperature=_TEMPERATURE_EVALUATE,
+            max_output_tokens=_MAX_OUTPUT_TOKENS_EVALUATE,
+            response_schema=ai_prompts.EVALUATION_SCHEMA,
+        )
         logger.debug(f"Gemini evaluate response: {text}")
         return response_parser.parse_evaluate_article(text)

--- a/ai/openai_service.py
+++ b/ai/openai_service.py
@@ -7,8 +7,7 @@ _API_URL = "http://localhost:1234/v1/chat/completions"
 _MODEL = "microsoft/phi-4-reasoning-plus"
 
 # Provider-specific sampling — kept here so other providers stay independent.
-_TEMPERATURE_EVALUATE = 0.2
-_TEMPERATURE_SUMMARIZE = 0.7
+_TEMPERATURE = 0.4
 
 
 def _wrap_article(article_text):
@@ -37,23 +36,14 @@ class OpenAIService(BaseAIService):
         resp.raise_for_status()
         return resp.json()["choices"][0]["message"]["content"]
 
-    def summarize_with_emojis(self, article_text, target_language='en', source_language='es'):
+    def evaluate_and_summarize(self, article_text, source_language='es', target_language='en'):
         messages = [
-            {"role": "system", "content": ai_prompts.get_summarize_with_emojis_prompt(target_language, source_language)},
-            {"role": "user", "content": _wrap_article(article_text)},
-        ]
-        return response_parser.parse_summary_with_emojis(
-            self._chat(messages, temperature=_TEMPERATURE_SUMMARIZE)
-        )
-
-    def evaluate_article(self, article_text, source_language='es'):
-        messages = [
-            {"role": "system", "content": ai_prompts.get_evaluate_article_prompt(source_language)},
+            {"role": "system", "content": ai_prompts.get_evaluate_and_summarize_prompt(source_language, target_language)},
             {"role": "user", "content": _wrap_article(article_text)},
         ]
         text = self._chat(
             messages,
-            temperature=_TEMPERATURE_EVALUATE,
+            temperature=_TEMPERATURE,
             response_format=_json_schema_response_format(ai_prompts.EVALUATION_SCHEMA),
         )
-        return response_parser.parse_evaluate_article(text)
+        return response_parser.parse_evaluate_and_summarize(text)

--- a/ai/openai_service.py
+++ b/ai/openai_service.py
@@ -4,46 +4,56 @@ import ai.ai_prompts as ai_prompts
 import response_parser
 
 _API_URL = "http://localhost:1234/v1/chat/completions"
+_MODEL = "microsoft/phi-4-reasoning-plus"
+
+# Provider-specific sampling — kept here so other providers stay independent.
+_TEMPERATURE_EVALUATE = 0.2
+_TEMPERATURE_SUMMARIZE = 0.7
+
+
+def _wrap_article(article_text):
+    return f"<article>\n{article_text}\n</article>"
+
+
+def _json_schema_response_format(schema, name="article_evaluation"):
+    return {
+        "type": "json_schema",
+        "json_schema": {"name": name, "schema": schema},
+    }
 
 
 class OpenAIService(BaseAIService):
     def __init__(self):
         self.headers = {"Authorization": "Bearer lm-studio", "Content-Type": "application/json"}
 
-    def _chat(self, messages, response_format={"type": "text"}, model="microsoft/phi-4-reasoning-plus"):
-        body = {"model": model, "messages": messages, "response_format": response_format, "temperature": 0.7}
+    def _chat(self, messages, *, temperature, response_format=None, model=_MODEL):
+        body = {
+            "model": model,
+            "messages": messages,
+            "response_format": response_format or {"type": "text"},
+            "temperature": temperature,
+        }
         resp = requests.post(_API_URL, json=body, headers=self.headers, timeout=120)
         resp.raise_for_status()
         return resp.json()["choices"][0]["message"]["content"]
 
-    def summarize_with_emojis(self, article_text, target_language='en'):
+    def summarize_with_emojis(self, article_text, target_language='en', source_language='es'):
         messages = [
-            {"role": "system", "content": ai_prompts.get_summarize_with_emojis_prompt(target_language)},
-            {"role": "user", "content": article_text}
+            {"role": "system", "content": ai_prompts.get_summarize_with_emojis_prompt(target_language, source_language)},
+            {"role": "user", "content": _wrap_article(article_text)},
         ]
-        return response_parser.parse_summary_with_emojis(self._chat(messages))
+        return response_parser.parse_summary_with_emojis(
+            self._chat(messages, temperature=_TEMPERATURE_SUMMARIZE)
+        )
 
-    def evaluate_article(self, article_text):
-        response_format = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": "article_evaluation",
-                "schema": {
-                    "type": "object",
-                    "properties": {
-                        "expat_impact": {"type": "integer", "minimum": 1, "maximum": 10, "description": "How relevant or impactful the news is for expatriates (1-10)"},
-                        "event_weight": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Significance or uniqueness of the event (1-10)"},
-                        "politics": {"type": "integer", "minimum": 0, "maximum": 10, "description": "Non-political/innovation score (0=political, 10=non-political/innovative)"},
-                        "timeliness": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Time-sensitivity or urgency (1-10)"},
-                        "practical_utility": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Usefulness for reader's daily life (1-10)"}
-                    },
-                    "required": ["expat_impact", "event_weight", "politics", "timeliness", "practical_utility"],
-                    "additionalProperties": False
-                }
-            }
-        }
+    def evaluate_article(self, article_text, source_language='es'):
         messages = [
-            {"role": "system", "content": ai_prompts.get_evaluate_article_prompt()},
-            {"role": "user", "content": article_text}
+            {"role": "system", "content": ai_prompts.get_evaluate_article_prompt(source_language)},
+            {"role": "user", "content": _wrap_article(article_text)},
         ]
-        return response_parser.parse_evaluate_article(self._chat(messages, response_format=response_format))
+        text = self._chat(
+            messages,
+            temperature=_TEMPERATURE_EVALUATE,
+            response_format=_json_schema_response_format(ai_prompts.EVALUATION_SCHEMA),
+        )
+        return response_parser.parse_evaluate_article(text)

--- a/claude.md
+++ b/claude.md
@@ -1,0 +1,114 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A news aggregation bot that scrapes Málaga news articles, evaluates their relevance using AI, and posts curated content to a Telegram channel. The bot runs on a 10-minute scheduler.
+
+## Commands
+
+### Setup
+```bash
+source .venv/bin/activate       # Activate virtual environment
+pip install -r requirements.txt
+```
+
+### Run
+```bash
+python3 main.py                 # Start the bot (runs indefinitely via scheduler)
+python3 main.py --dry-run       # One cycle: fetch + evaluate + summarize without posting or saving, then exit
+```
+
+Dry runs log per-article results (status, score breakdown, summary) to a timestamped JSON file under `dry_run_logs/` via [dry_run_logger.py](dry_run_logger.py) — used for comparing score distributions before/after prompt changes. Dry runs do not write to the seen-cache or Supabase.
+
+### Tests
+```bash
+python3 -m unittest discover -s tests -p "test_*.py"   # Run all tests
+python3 -m unittest tests.test_ai_services              # Run specific test module
+```
+
+### Lint
+No linter is configured. Use `flake8` or `ruff` if needed.
+
+## Architecture
+
+The bot runs a scheduled `job()` function in [main.py](main.py) every 10 minutes. The per-article pipeline is ordered **cheapest-first** so free checks always run before quota-consuming API calls (free-tier Gemini quotas are requests-per-day bound, not token bound):
+
+1. **Retry pending posts** — Telegram posts that failed earlier are re-sent from the in-memory `_pending_posts` queue without new LLM calls (the summary is already paid for); after 3 failed attempts the URL is marked `post_failed` in the seen-cache
+2. **Fetch list** — [fetching_data.py](fetching_data.py) scrapes article links from the homepage. If the (filtered) list is byte-identical to the last cleanly-completed cycle (SHA-1 hash), the whole cycle is skipped for free
+3. **Skip checks (free)** — per article: URL exact-match via `is_url_seen()` against the cached `known_articles` list, then [seen_cache.py](seen_cache.py) — a persistent JSON cache (`seen_cache.json`) of terminal outcomes (`too_old`, `no_content`, `duplicate`, `post_failed`) and transient-failure attempt counters (terminal after 3 attempts). This prevents unsaveable articles from being re-processed every cycle
+4. **Fetch article (free)** — `fetch_article()` returns `(soup, date_time)` or a status string: `"fetch_failed"` (HTTP/parse error, missing `<h1>` or timestamp) or `"too_old"` (older than 7 days). Failures are recorded in the seen-cache *before* any API call is spent
+5. **Deduplicate (1 embed call)** — title cosine similarity via Gemini embeddings + `is_new_article_cached()` in [data_service.py](data_service.py) (threshold 0.85); falls back to Jaccard on legacy rows without embeddings. The embedding is returned and reused on save
+6. **Evaluate + summarize (1 generation call)** — a single combined LLM call scores 5 dimensions (`expat_impact`, `event_weight`, `politics`, `timeliness`, `practical_utility`) **and** produces the emoji-rich summary (`EVALUATION_SCHEMA` in [ai/ai_prompts.py](ai/ai_prompts.py)). The final score is the mean of all five dimensions (a `politics: 0` lowers it). Articles scoring below 6 are **saved to Supabase** (to prevent re-evaluation next cycle) and skipped
+7. **Post** — [telegram_service.py](telegram_service.py) sends media groups (up to 9 images) or text; on failure the composed message is queued in `_pending_posts` for retry
+8. **Save** — title, URL, and embedding saved to Supabase after a confirmed post and appended to the in-memory `known_articles` (so a same-story second URL in the same cycle is deduplicated); if the save fails, the URL is recorded as `posted` in the seen-cache to prevent a duplicate post
+9. **Cleanup** — Daily job removes Supabase entries older than 10 days; the seen-cache self-prunes entries not seen for 14 days
+
+A planned refactor to support multiple news sources (turning `FetchingData` into a `BaseScraper` ABC with per-source subclasses under `scrapers/`) is documented in [MULTI_SOURCE_DESIGN.md](MULTI_SOURCE_DESIGN.md) — not yet implemented.
+
+### AI Provider Abstraction (`ai/`)
+
+Factory pattern with pluggable providers:
+- [ai_service.py](ai/ai_service.py) — `AIService.get_service(provider)` factory
+- [base_ai_service.py](ai/base_ai_service.py) — Abstract base with a single `evaluate_and_summarize()` method (one request per article); also defines the generic `RateLimitError` (carries `retry_after` seconds)
+- [gemini_service.py](ai/gemini_service.py) — Google Gemini (configurable via `GEMINI_MODEL` env var, defaults to `gemini-2.5-flash-lite`). Uses the standard-JSON-Schema `responseJsonSchema` field for structured output; if the API rejects it (HTTP 400), automatically falls back process-wide to the legacy OpenAPI-subset `responseSchema` (sanitized via `_sanitize_schema`)
+- [openai_service.py](ai/openai_service.py) — OpenAI or local LM Studio (`http://localhost:1234/v1`)
+- [ai_prompts.py](ai/ai_prompts.py) — All prompt templates
+- [ai_provider.py](ai/ai_provider.py) — `AIProvider` enum (`GEMINI`, `OPENAI`)
+
+Switch providers by changing `AIProvider.GEMINI` / `AIProvider.OPENAI` in [main.py](main.py).
+
+### Gemini Rate-Limit Handling
+
+Free-tier quotas (`gemini-2.5-flash-lite`: 15 RPM / 1,000 RPD; `gemini-2.5-flash`: 10 RPM / 250 RPD) are easy to exhaust. [ai/gemini_service.py](ai/gemini_service.py) defends against this with:
+
+- **Call staggering** — a class-level monotonic timestamp + lock enforces a minimum gap between *every* Gemini call (default 6.5s, configurable via `GEMINI_MIN_CALL_INTERVAL_SEC`). Keeps RPM safely under the cap.
+- **`GeminiRateLimitError` on HTTP 429** — subclasses the generic `RateLimitError` from [ai/base_ai_service.py](ai/base_ai_service.py); carries the suggested delay parsed from either the `Retry-After` header or Google's `error.details[].retryDelay` JSON field.
+- **`_with_retry()` in [main.py](main.py)** — when the raised exception has a `retry_after` attribute, it waits exactly that long instead of falling back to exponential backoff; also sets `_rate_limited` to abort the current job cycle early.
+- **Thinking disabled** — `thinkingBudget: 0` is set on every request so Gemini 2.5 thought tokens don't starve `maxOutputTokens`.
+
+### Key Configuration
+
+All credentials live in `.env` (loaded via `python-dotenv`):
+```
+BOT_TOKEN                        # Telegram bot token
+CHAT_ID                          # Target Telegram channel/chat
+NEWS_URL                         # Source URL (malagahoy.es/malaga/)
+GEMINI_API_KEY                   # Google Generative AI key (used for both generation and embeddings)
+SUPABASE_URL                     # Supabase project URL
+SUPABASE_KEY                     # Supabase service role key
+GEMINI_MODEL                     # Optional: Gemini model name (default: gemini-2.5-flash-lite)
+GEMINI_MIN_CALL_INTERVAL_SEC     # Optional: min seconds between Gemini calls (default: 6.5)
+LOG_LEVEL                        # Optional: logging level (default: INFO)
+```
+
+Constants in [main.py](main.py):
+- `SIMILARITY_THRESHOLD = 0.85` — cosine similarity cutoff for duplicate detection
+- `SCORE_THRESHOLD = 6` — minimum average score for posting
+- `MAX_POST_ATTEMPTS = 3` — Telegram retry budget before a post is abandoned
+
+### Response Parsing
+
+[response_parser.py](response_parser.py) — `parse_evaluate_and_summarize()` strips `<think>` tags and markdown fences, parses the JSON, and returns `{'score', 'breakdown', 'summary'}` — or `None` on invalid JSON, so callers can distinguish "model failed" from "article scored low". Schema enforcement happens provider-side (`responseJsonSchema` / `json_schema` response format).
+
+## Dependencies
+
+See [requirements.txt](requirements.txt) for runtime dependencies:
+- `beautifulsoup4` + `requests` — Web scraping
+- `numpy` — Cosine similarity computation
+- `python-dotenv` — Environment variable loading
+
+Dev/test-only packages are in [requirements-dev.txt](requirements-dev.txt).
+
+## Testing
+
+Tests use `unittest`. Coverage is mixed mock/integration:
+
+- [tests/test_ai_services.py](tests/test_ai_services.py) — `evaluate_and_summarize()` for both providers with mocked HTTP clients, including the `responseJsonSchema` → legacy fallback and 429/`retry_after` parsing
+- [tests/test_response_parser.py](tests/test_response_parser.py) — combined-response parsing: scoring math (zeros count), fence/think-tag stripping, `None` on invalid JSON
+- [tests/test_seen_cache.py](tests/test_seen_cache.py) — seen-cache skip/attempt/prune/persistence behavior (tempdir, no network)
+- [tests/test_similarity.py](tests/test_similarity.py) — pure-numpy cosine math; real Gemini embedding calls (skipped when `GEMINI_API_KEY` is absent); `DataService` similarity with mocked Supabase
+- [tests/test_supabase_connection.py](tests/test_supabase_connection.py) — **real Supabase integration** (CRUD round-trips); reads credentials from `.env` directly
+
+Integration tests hit live APIs when keys are present in `.env` — be mindful of Gemini free-tier quotas when running the full suite.

--- a/data_service.py
+++ b/data_service.py
@@ -6,7 +6,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-_EMBED_URL = "https://api.cohere.com/v1/embed"
+_EMBED_URL = "https://api.cohere.com/v2/embed"
 _EMBED_MODEL = "embed-multilingual-v3.0"
 
 
@@ -33,11 +33,12 @@ class DataService:
                 "texts": [text],
                 "model": _EMBED_MODEL,
                 "input_type": "search_document",
+                "embedding_types": ["float"],
             },
             timeout=20,
         )
         resp.raise_for_status()
-        return resp.json()["embeddings"][0]
+        return resp.json()["embeddings"]["float"][0]
 
     def _cosine(self, a, b):
         a, b = np.array(a), np.array(b)

--- a/dry_run_logger.py
+++ b/dry_run_logger.py
@@ -1,0 +1,65 @@
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class DryRunLogger:
+    """Collects evaluation results during a dry-run and persists them to a timestamped JSON file.
+
+    Each dry-run produces one self-contained file under `output_dir/` for offline analysis
+    (e.g. comparing score distributions before/after prompt changes).
+    """
+
+    def __init__(self, output_dir="dry_run_logs"):
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.path = self.output_dir / f"dry_run_{ts}.json"
+        self._records = []
+        self.started_at = datetime.now(timezone.utc).isoformat()
+        logger.info(f"[dry-run] Logging results to {self.path}")
+
+    def record(self, *, title, url, status, score=None, breakdown=None, summary=None,
+               language=None, article_chars=None, error=None):
+        """Append one article result and persist atomically.
+
+        status values: 'evaluated_above_threshold', 'below_threshold',
+        'evaluate_failed', 'summary_failed', 'fetch_failed', 'too_old',
+        'no_content', 'duplicate_cached'.
+
+        breakdown: per-dimension scores dict (expat_impact, event_weight,
+        politics, timeliness, practical_utility) — critical for analyzing
+        whether prompt changes affected specific dimensions.
+        """
+        self._records.append({
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "title": title,
+            "url": url,
+            "status": status,
+            "score": score,
+            "breakdown": breakdown,
+            "summary": summary,
+            "language": language,
+            "article_chars": article_chars,
+            "error": error,
+        })
+        self._flush()
+
+    def _flush(self):
+        payload = {
+            "started_at": self.started_at,
+            "finished_at": datetime.now(timezone.utc).isoformat(),
+            "count": len(self._records),
+            "results": self._records,
+        }
+        tmp = self.path.with_suffix(".json.tmp")
+        with tmp.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        tmp.replace(self.path)
+
+    def close(self):
+        self._flush()
+        logger.info(f"[dry-run] Wrote {len(self._records)} records to {self.path}")

--- a/fetching_data.py
+++ b/fetching_data.py
@@ -77,7 +77,12 @@ class FetchingData:
         return [url for url in unique_urls if url.endswith('.jpg') and f'_{max_resolution}w_' in url]
 
     def fetch_article(self, title, href):
-        """Fetch article page and validate date. Returns (soup, date_time) or None."""
+        """Fetch article page and validate date.
+
+        Returns (soup, date_time) on success, or a string status describing the
+        failure: "fetch_failed" (HTTP/parse error or missing required nodes) or
+        "too_old" (article date older than 7 days).
+        """
         logger.info(f"Fetching article: {title}")
         try:
             resp = requests.get(href, headers=self.headers, timeout=15)
@@ -87,33 +92,33 @@ class FetchingData:
             h1 = soup.find('h1')
             if not h1:
                 logger.warning(f"[fetch] No <h1> on {href}")
-                return None
+                return "fetch_failed"
             logger.info(f"Article title: {h1.get_text(strip=True)}")
 
             date_node = soup.find('p', class_='timestamp-atom')
             if not date_node:
                 logger.warning(f"[fetch] No timestamp on {href}")
-                return None
+                return "fetch_failed"
 
             try:
                 date_time = self._parse_spanish_date(date_node.text)
             except (ValueError, IndexError) as e:
                 logger.warning(f"[fetch] Date parse failed for {href}: {e}")
-                return None
+                return "fetch_failed"
 
             logger.info(f"Article date: {date_time}")
             if date_time < datetime.now() - timedelta(days=7):
                 logger.info("Article is older than 7 days, skipping.")
-                return None
+                return "too_old"
 
             return soup, date_time
 
         except requests.RequestException as e:
             logger.error(f"[fetch] HTTP error for {href}: {e}")
-            return None
+            return "fetch_failed"
         except Exception as e:
             logger.error(f"[fetch] Unexpected error for {href}: {e!r}")
-            return None
+            return "fetch_failed"
 
     def parse_content(self, soup):
         """Extract text content and images from an already-fetched soup object."""

--- a/fetching_data.py
+++ b/fetching_data.py
@@ -8,9 +8,10 @@ logger = logging.getLogger(__name__)
 
 
 class FetchingData:
-    def __init__(self, news_url, headers):
+    def __init__(self, news_url, headers, language='es'):
         self.news_url = news_url
         self.headers = headers
+        self.language = language
 
     def fetch_latest_articles(self):
         logger.info(f"Fetching latest articles from: {self.news_url}")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import signal
+import hashlib
 import threading
 import random
 import logging
@@ -11,6 +12,7 @@ from fetching_data import FetchingData
 from ai.ai_service import AIService
 from telegram_service import TelegramService
 from data_service import DataService
+from seen_cache import SeenCache
 from ai.ai_provider import AIProvider
 from ai.base_ai_service import RateLimitError
 from dry_run_logger import DryRunLogger
@@ -25,6 +27,8 @@ logger = logging.getLogger(__name__)
 HEADERS = {"User-Agent": "Mozilla/5.0"}
 SIMILARITY_THRESHOLD = 0.85
 DISTANCE_THRESHOLD = 1 - SIMILARITY_THRESHOLD
+SCORE_THRESHOLD = 6
+MAX_POST_ATTEMPTS = 3
 BOT_TOKEN = os.getenv('BOT_TOKEN')
 CHAT_ID = os.getenv('CHAT_ID')
 NEWS_URL = os.getenv('NEWS_URL')
@@ -43,9 +47,15 @@ data_service = DataService(supabase_url=SUPABASE_URL, supabase_key=SUPABASE_KEY,
 fetch_service = FetchingData(NEWS_URL, HEADERS)
 telegram_service = TelegramService(BOT_TOKEN, CHAT_ID)
 ai_service = AIService.get_service(provider=current_ai_provider, gemini_api_key=GEMINI_API_KEY)
+seen_cache = SeenCache()
 
 _shutdown = threading.Event()
 _rate_limited = False  # circuit breaker: True when Gemini returns 429
+_last_articles_hash = None  # homepage fingerprint of the last cleanly-completed cycle
+# Telegram-post payloads waiting for retry: href -> {message, images, title,
+# date_time, embedding, attempts}. The LLM work is already paid for, so a
+# failed post must never trigger a re-evaluation.
+_pending_posts = {}
 
 
 def _with_retry(fn, retries=5, base_delay=20):
@@ -77,26 +87,78 @@ def _with_retry(fn, retries=5, base_delay=20):
     return None
 
 
+def _retry_pending_posts():
+    """Re-send posts that failed on Telegram's side — no LLM calls involved."""
+    for href in list(_pending_posts):
+        if _shutdown.is_set():
+            return
+        pending = _pending_posts[href]
+        attempt = pending["attempts"] + 1
+        logger.info(f"Retrying Telegram post for '{pending['title']}' (attempt {attempt}/{MAX_POST_ATTEMPTS})")
+        if telegram_service.post_to_telegram(pending["message"], pending["images"], href):
+            _finalize_posted(pending["title"], pending["date_time"], href, pending["embedding"])
+            del _pending_posts[href]
+        else:
+            pending["attempts"] = attempt
+            if attempt >= MAX_POST_ATTEMPTS:
+                logger.error(f"Giving up on posting '{pending['title']}' after {MAX_POST_ATTEMPTS} attempts.")
+                seen_cache.record_terminal(href, "post_failed")
+                del _pending_posts[href]
+
+
+def _finalize_posted(title, date_time, href, embedding, known_articles=None):
+    """Persist a successfully posted article; fall back to the seen-cache so a
+    Supabase hiccup can't cause a duplicate post next cycle."""
+    if data_service.save_article(title, date_time, url=href, embedding=embedding):
+        if known_articles is not None:
+            known_articles.append({"title": title, "url": href, "embedding": embedding})
+    else:
+        logger.warning(f"Posted '{title}' but failed to save — recording in seen-cache to prevent a duplicate post.")
+        seen_cache.record_terminal(href, "posted")
+
+
 def job(dry_run=False):
-    global _rate_limited
+    global _rate_limited, _last_articles_hash
     _rate_limited = False
     dry_run_log = DryRunLogger() if dry_run else None
+
+    if not dry_run:
+        _retry_pending_posts()
+
     logger.info("Fetching latest articles...")
-    new_articles = fetch_service.fetch_latest_articles()
-    logger.info(f"Found {len(new_articles)} new articles.")
+    new_articles = [
+        (title, href) for title, href in fetch_service.fetch_latest_articles()
+        if href and len(title.strip()) >= 20
+    ]
+    logger.info(f"Found {len(new_articles)} candidate articles.")
+    if not new_articles:
+        if dry_run_log:
+            dry_run_log.close()
+        return
+
+    # Free short-circuit: if the homepage shows exactly the same articles as the
+    # last fully-completed cycle, there is nothing new to do.
+    articles_hash = hashlib.sha1(repr(new_articles).encode("utf-8")).hexdigest()
+    if not dry_run and articles_hash == _last_articles_hash:
+        logger.info("Homepage unchanged since last completed cycle — skipping.")
+        return
+
     known_articles = data_service.fetch_recent_articles()
+    completed = True
     try:
         for title, href in new_articles:
             if _shutdown.is_set():
+                completed = False
                 break
             if _rate_limited:
                 logger.warning("Gemini rate-limited — aborting job cycle early, will retry next run.")
+                completed = False
                 break
-            if not href or len(title.strip()) < 20:
-                logger.debug(f"Skipping invalid article entry: '{title}'")
-                continue
             if data_service.is_url_seen(href, known_articles):
-                logger.info(f"Skipping already-seen URL: {href}")
+                logger.debug(f"Skipping already-seen URL: {href}")
+                continue
+            if seen_cache.should_skip(href):
+                logger.debug(f"Skipping cached terminal URL: {href}")
                 continue
             try:
                 _process_article(title, href, known_articles, dry_run=dry_run, dry_run_log=dry_run_log)
@@ -104,30 +166,35 @@ def job(dry_run=False):
                 logger.error(f"[job] Article '{title}' failed: {e!r}")
                 if dry_run_log:
                     dry_run_log.record(title=title, url=href, status="exception", error=repr(e))
+                elif not _rate_limited:
+                    seen_cache.record_attempt(href, "exception")
             if _shutdown.wait(timeout=5):
+                completed = False
                 break
     finally:
         if dry_run_log:
             dry_run_log.close()
+        seen_cache.flush_if_dirty()
+    if completed and not _rate_limited and not dry_run:
+        _last_articles_hash = articles_hash
     logger.info("Job finished.")
- 
+
 
 def _process_article(title, href, known_articles, dry_run=False, dry_run_log=None):
+    """Pipeline ordered cheapest-first: free HTTP/date/content checks, then one
+    embedding call for dedup, then a single combined evaluate+summarize call."""
     logger.info(f"Processing article: {title}")
-    is_new, title_embedding = data_service.is_new_article_cached(title, known_articles)
-    if not is_new:
-        logger.info(f"Article '{title}' already processed, skipping.")
-        if dry_run_log:
-            dry_run_log.record(title=title, url=href, status="duplicate_cached")
-        return
-
     logger.info("Fetching article metadata...")
     meta = fetch_service.fetch_article(title, href)
     if isinstance(meta, str):
         if meta == "too_old":
             logger.info("Article is too old, skipping.")
+            if not dry_run:
+                seen_cache.record_terminal(href, "too_old")
         else:
             logger.warning("Failed to fetch article.")
+            if not dry_run:
+                seen_cache.record_attempt(href, meta)
         if dry_run_log:
             dry_run_log.record(title=title, url=href, status=meta)
         return
@@ -136,25 +203,41 @@ def _process_article(title, href, known_articles, dry_run=False, dry_run_log=Non
 
     if not main_content:
         logger.warning("Article content is missing.")
+        if not dry_run:
+            seen_cache.record_terminal(href, "no_content")
         if dry_run_log:
             dry_run_log.record(title=title, url=href, status="no_content")
         return
 
-    logger.info("Evaluating main content...")
-    eval_result = _with_retry(lambda: ai_service.evaluate_article(main_content, fetch_service.language))
-    article_score = eval_result["score"] if eval_result else None
-    breakdown = eval_result["breakdown"] if eval_result else None
-    if not article_score:
-        logger.warning(f"Failed to evaluate article '{title}'. Skipping.")
+    is_new, title_embedding = data_service.is_new_article_cached(title, known_articles)
+    if not is_new:
+        logger.info(f"Article '{title}' already processed, skipping.")
+        if not dry_run:
+            seen_cache.record_terminal(href, "duplicate")
+        if dry_run_log:
+            dry_run_log.record(title=title, url=href, status="duplicate_cached")
+        return
+
+    logger.info("Evaluating and summarizing article...")
+    result = _with_retry(lambda: ai_service.evaluate_and_summarize(
+        main_content, source_language=fetch_service.language, target_language='en'))
+    if result is None or not result["summary"]:
+        status = "evaluate_failed" if result is None else "summary_failed"
+        logger.warning(f"LLM processing failed ({status}) for '{title}'. Skipping.")
+        if not dry_run and not _rate_limited:
+            seen_cache.record_attempt(href, status)
         if dry_run_log:
             dry_run_log.record(
-                title=title, url=href, status="evaluate_failed",
+                title=title, url=href, status=status,
                 language=fetch_service.language, article_chars=len(main_content),
             )
         return
+    article_score = result["score"]
+    breakdown = result["breakdown"]
+    summary = result["summary"]
 
-    logger.info(f"Article score: {article_score}")
-    if article_score < 6:
+    logger.info(f"Article score: {article_score:.1f}")
+    if article_score < SCORE_THRESHOLD:
         logger.info(f"Article '{title}' scored {article_score:.1f}, below threshold. Skipping.")
         if dry_run_log:
             dry_run_log.record(
@@ -162,42 +245,33 @@ def _process_article(title, href, known_articles, dry_run=False, dry_run_log=Non
                 language=fetch_service.language, article_chars=len(main_content),
             )
         if not dry_run:
-            data_service.save_article(title, date_time, url=href, embedding=title_embedding)
-        return
-
-    logger.info("Summarizing with emojis...")
-    evaluated_content = _with_retry(lambda: ai_service.summarize_with_emojis(main_content, target_language='en', source_language=fetch_service.language))
-
-    if not evaluated_content or not evaluated_content.strip():
-        logger.warning(f"Failed to summarize article '{title}' with emojis. Skipping.")
-        if dry_run_log:
-            dry_run_log.record(
-                title=title, url=href, status="summary_failed", score=article_score, breakdown=breakdown,
-                language=fetch_service.language, article_chars=len(main_content),
-            )
+            if data_service.save_article(title, date_time, url=href, embedding=title_embedding):
+                known_articles.append({"title": title, "url": href, "embedding": title_embedding})
+            else:
+                seen_cache.record_attempt(href, "save_failed")
         return
 
     if dry_run:
         if dry_run_log:
             dry_run_log.record(
                 title=title, url=href, status="evaluated_above_threshold",
-                score=article_score, breakdown=breakdown, summary=evaluated_content,
+                score=article_score, breakdown=breakdown, summary=summary,
                 language=fetch_service.language, article_chars=len(main_content),
             )
         return
 
     logger.info("Posting to Telegram...")
-    result_of_post = telegram_service.post_to_telegram(f"<b>{title}</b>\n\n{evaluated_content}", images, href)
-    if not result_of_post:
-        logger.error(f"Failed to post article '{title}' to Telegram, will retry next cycle.")
+    message = f"<b>{title}</b>\n\n{summary}"
+    if not telegram_service.post_to_telegram(message, images, href):
+        logger.error(f"Failed to post article '{title}' to Telegram — queued for retry without re-evaluation.")
+        _pending_posts[href] = {
+            "message": message, "images": images, "title": title,
+            "date_time": date_time, "embedding": title_embedding, "attempts": 1,
+        }
         return
 
     logger.info("Saving article...")
-    if not data_service.save_article(title, date_time, url=href, embedding=title_embedding):
-        logger.warning(f"Posted '{title}' but failed to save — may duplicate next run.")
-
-    if _shutdown.wait(timeout=10):
-        return
+    _finalize_posted(title, date_time, href, title_embedding, known_articles)
 
 
 def _handle_signal(signum, _frame):
@@ -211,8 +285,8 @@ if __name__ == "__main__":
 
     dry_run = '--dry-run' in sys.argv
     job(dry_run=dry_run)
-    # if dry_run:
-    #     sys.exit(0)
+    if dry_run:
+        sys.exit(0)
 
     next_job = datetime.now() + timedelta(minutes=10)
     last_cleanup_day = date.today()
@@ -221,7 +295,7 @@ if __name__ == "__main__":
         if _shutdown.wait(timeout=60):
             break
         now = datetime.now()
-        logger.info(f"Scheduler tick at {now.strftime('%Y-%m-%d %H:%M:%S')}")
+        logger.debug(f"Scheduler tick at {now.strftime('%Y-%m-%d %H:%M:%S')}")
 
         if now.date() > last_cleanup_day:
             try:

--- a/main.py
+++ b/main.py
@@ -123,10 +123,13 @@ def _process_article(title, href, known_articles, dry_run=False, dry_run_log=Non
 
     logger.info("Fetching article metadata...")
     meta = fetch_service.fetch_article(title, href)
-    if not meta:
-        logger.warning("Failed to fetch article or article is too old.")
+    if isinstance(meta, str):
+        if meta == "too_old":
+            logger.info("Article is too old, skipping.")
+        else:
+            logger.warning("Failed to fetch article.")
         if dry_run_log:
-            dry_run_log.record(title=title, url=href, status="fetch_failed_or_too_old")
+            dry_run_log.record(title=title, url=href, status=meta)
         return
     soup, date_time = meta
     main_content, images = fetch_service.parse_content(soup)

--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ from ai.ai_service import AIService
 from telegram_service import TelegramService
 from data_service import DataService
 from ai.ai_provider import AIProvider
+from ai.base_ai_service import RateLimitError
+from dry_run_logger import DryRunLogger
 
 load_dotenv()
 
@@ -53,9 +55,15 @@ def _with_retry(fn, retries=5, base_delay=20):
     for attempt in range(1, retries + 1):
         try:
             return fn()
+        except RateLimitError as e:
+            _rate_limited = True
+            logger.warning(f"LLM rate-limited (attempt {attempt}/{retries}): {e}")
+            if attempt < retries:
+                sleep = (e.retry_after + 1) if e.retry_after else base_delay * (2 ** (attempt - 1))
+                logger.info(f"Retrying in {sleep:.1f}s (provider-suggested)...")
+                if _shutdown.wait(timeout=sleep):
+                    return None
         except Exception as e:
-            if '429' in str(e):
-                _rate_limited = True
             logger.warning(f"LLM error (attempt {attempt}/{retries}): {e!r}")
             if attempt < retries:
                 sleep = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)
@@ -68,70 +76,106 @@ def _with_retry(fn, retries=5, base_delay=20):
 def job(dry_run=False):
     global _rate_limited
     _rate_limited = False
+    dry_run_log = DryRunLogger() if dry_run else None
     logger.info("Fetching latest articles...")
     new_articles = fetch_service.fetch_latest_articles()
     logger.info(f"Found {len(new_articles)} new articles.")
     known_articles = data_service.fetch_recent_articles()
-    for title, href in new_articles:
-        if _shutdown.is_set():
-            break
-        if _rate_limited:
-            logger.warning("Gemini rate-limited — aborting job cycle early, will retry next run.")
-            break
-        if not href or len(title.strip()) < 20:
-            logger.debug(f"Skipping invalid article entry: '{title}'")
-            continue
-        if data_service.is_url_seen(href, known_articles):
-            logger.info(f"Skipping already-seen URL: {href}")
-            continue
-        try:
-            _process_article(title, href, known_articles, dry_run=dry_run)
-        except Exception as e:
-            logger.error(f"[job] Article '{title}' failed: {e!r}")
-        if _shutdown.wait(timeout=5):
-            break
+    try:
+        for title, href in new_articles:
+            if _shutdown.is_set():
+                break
+            if _rate_limited:
+                logger.warning("Gemini rate-limited — aborting job cycle early, will retry next run.")
+                break
+            if not href or len(title.strip()) < 20:
+                logger.debug(f"Skipping invalid article entry: '{title}'")
+                continue
+            if data_service.is_url_seen(href, known_articles):
+                logger.info(f"Skipping already-seen URL: {href}")
+                continue
+            try:
+                _process_article(title, href, known_articles, dry_run=dry_run, dry_run_log=dry_run_log)
+            except Exception as e:
+                logger.error(f"[job] Article '{title}' failed: {e!r}")
+                if dry_run_log:
+                    dry_run_log.record(title=title, url=href, status="exception", error=repr(e))
+            if _shutdown.wait(timeout=5):
+                break
+    finally:
+        if dry_run_log:
+            dry_run_log.close()
     logger.info("Job finished.")
 
 
-def _process_article(title, href, known_articles, dry_run=False):
+def _process_article(title, href, known_articles, dry_run=False, dry_run_log=None):
     logger.info(f"Processing article: {title}")
     if not data_service.is_new_article_cached(title, known_articles):
         logger.info(f"Article '{title}' already processed, skipping.")
+        if dry_run_log:
+            dry_run_log.record(title=title, url=href, status="duplicate_cached")
         return
 
     logger.info("Fetching article metadata...")
     meta = fetch_service.fetch_article(title, href)
     if not meta:
         logger.warning("Failed to fetch article or article is too old.")
+        if dry_run_log:
+            dry_run_log.record(title=title, url=href, status="fetch_failed_or_too_old")
         return
     soup, date_time = meta
     main_content, images = fetch_service.parse_content(soup)
 
     if not main_content:
         logger.warning("Article content is missing.")
+        if dry_run_log:
+            dry_run_log.record(title=title, url=href, status="no_content")
         return
 
     logger.info("Evaluating main content...")
-    article_score = _with_retry(lambda: ai_service.evaluate_article(main_content))
+    eval_result = _with_retry(lambda: ai_service.evaluate_article(main_content, fetch_service.language))
+    article_score = eval_result["score"] if eval_result else None
+    breakdown = eval_result["breakdown"] if eval_result else None
     if not article_score:
         logger.warning(f"Failed to evaluate article '{title}'. Skipping.")
+        if dry_run_log:
+            dry_run_log.record(
+                title=title, url=href, status="evaluate_failed",
+                language=fetch_service.language, article_chars=len(main_content),
+            )
         return
 
     logger.info(f"Article score: {article_score}")
     if article_score < 6:
         logger.info(f"Article '{title}' scored {article_score:.1f}, below threshold. Skipping.")
+        if dry_run_log:
+            dry_run_log.record(
+                title=title, url=href, status="below_threshold", score=article_score, breakdown=breakdown,
+                language=fetch_service.language, article_chars=len(main_content),
+            )
         if not dry_run:
             data_service.save_article(title, date_time, url=href)
         return
 
     logger.info("Summarizing with emojis...")
-    evaluated_content = _with_retry(lambda: ai_service.summarize_with_emojis(main_content, target_language='en'))
+    evaluated_content = _with_retry(lambda: ai_service.summarize_with_emojis(main_content, target_language='en', source_language=fetch_service.language))
 
     if not evaluated_content or not evaluated_content.strip():
         logger.warning(f"Failed to summarize article '{title}' with emojis. Skipping.")
+        if dry_run_log:
+            dry_run_log.record(
+                title=title, url=href, status="summary_failed", score=article_score, breakdown=breakdown,
+                language=fetch_service.language, article_chars=len(main_content),
+            )
         return
 
     if dry_run:
+        if dry_run_log:
+            dry_run_log.record(
+                title=title, url=href, status="evaluated_above_threshold",
+                score=article_score, breakdown=breakdown, summary=evaluated_content,
+                language=fetch_service.language, article_chars=len(main_content),
+            )
         return
 
     logger.info("Posting to Telegram...")
@@ -159,8 +203,8 @@ if __name__ == "__main__":
 
     dry_run = '--dry-run' in sys.argv
     job(dry_run=dry_run)
-    if dry_run:
-        sys.exit(0)
+    # if dry_run:
+    #     sys.exit(0)
 
     next_job = datetime.now() + timedelta(minutes=10)
     last_cleanup_day = date.today()

--- a/response_parser.py
+++ b/response_parser.py
@@ -35,25 +35,27 @@ def parse_summary_with_emojis_and_evaluate(response_text):
     return summary_text, final_score
 
 
-def parse_evaluate_article(response_text):
-    cleaned_response_text = re.sub(r'<think>.*?</think>', '', response_text, flags=re.DOTALL).strip()
-    cleaned_response_text = re.sub(r'//.*', '', cleaned_response_text)
+_EVALUATION_KEYS = ("expat_impact", "event_weight", "politics", "timeliness", "practical_utility")
 
-    cleaned_response_text = re.sub(r'^```(?:json)?\s*', '', cleaned_response_text)
-    cleaned_response_text = re.sub(r'\s*```$', '', cleaned_response_text).strip()
+
+def parse_evaluate_article(response_text):
+    """Parses the raw LLM response into {'score': float, 'breakdown': dict|None}.
+
+    Bot logic only needs `score`; `breakdown` is for dry-run analysis.
+    On JSON decode failure returns {'score': 0, 'breakdown': None}.
+    """
+    cleaned = re.sub(r'<think>.*?</think>', '', response_text, flags=re.DOTALL).strip()
+    cleaned = re.sub(r'//.*', '', cleaned)
+    cleaned = re.sub(r'^```(?:json)?\s*', '', cleaned)
+    cleaned = re.sub(r'\s*```$', '', cleaned).strip()
 
     try:
-        json_object = json.loads(cleaned_response_text)
-        expat_impact = json_object.get("expat_impact", 0)
-        event_weight = json_object.get("event_weight", 0)
-        politics_vs_innovation = json_object.get("politics", 0)
-        timeliness = json_object.get("timeliness", 0)
-        practical_utility = json_object.get("practical_utility", 0)
-
-        scores = [expat_impact, event_weight, politics_vs_innovation, timeliness, practical_utility]
-        non_zero_scores = [score for score in scores if score != 0]
-        total_score = sum(non_zero_scores) / len(non_zero_scores) if non_zero_scores else 0
-        return total_score
+        obj = json.loads(cleaned)
     except json.JSONDecodeError:
-        logger.error(f"Failed to decode JSON from response: {cleaned_response_text}")
-        return 0
+        logger.error(f"Failed to decode JSON from response: {cleaned}")
+        return {"score": 0, "breakdown": None}
+
+    breakdown = {key: obj.get(key, 0) for key in _EVALUATION_KEYS}
+    non_zero = [v for v in breakdown.values() if v != 0]
+    avg = sum(non_zero) / len(non_zero) if non_zero else 0
+    return {"score": avg, "breakdown": breakdown}

--- a/response_parser.py
+++ b/response_parser.py
@@ -4,58 +4,34 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-
-def parse_summary_with_emojis(response_text):
-    return re.sub(r'<think>.*?</think>', '', response_text, flags=re.DOTALL).strip()
-
-
-def parse_summary_with_emojis_and_evaluate(response_text):
-    cleaned_response_text = re.sub(r'<think>.*?</think>', '', response_text, flags=re.DOTALL).strip()
-
-    scores = {"expat_impact": 0, "malaga_relevance": 0, "feature_vs_politics": 0}
-    scores_match = re.search(r"Scores:\s*E:(\d{1,2})\s*M:(\d{1,2})\s*P:(\d{1,2})", cleaned_response_text, re.IGNORECASE)
-
-    summary_text = cleaned_response_text
-    if scores_match:
-        try:
-            scores["expat_impact"] = int(scores_match.group(1))
-            scores["malaga_relevance"] = int(scores_match.group(2))
-            scores["feature_vs_politics"] = int(scores_match.group(3))
-            summary_text = re.sub(r"Scores:\s*E:\d{1,2}\s*M:\d{1,2}\s*P:\d{1,2}", "", cleaned_response_text, flags=re.IGNORECASE).strip()
-        except ValueError:
-            logger.warning(f"Could not parse scores from AI response: {scores_match.groups()}")
-    else:
-        logger.warning(f"Scores pattern not found in AI response: '{cleaned_response_text}'")
-
-    expat_impact = scores.get("expat_impact", 0)
-    malaga_relevance = scores.get("malaga_relevance", 0)
-    feature_vs_politics = scores.get("feature_vs_politics", 0)
-    final_score = (expat_impact + malaga_relevance + feature_vs_politics) / len(scores) if scores else 0
-
-    return summary_text, final_score
-
-
 _EVALUATION_KEYS = ("expat_impact", "event_weight", "politics", "timeliness", "practical_utility")
 
 
-def parse_evaluate_article(response_text):
-    """Parses the raw LLM response into {'score': float, 'breakdown': dict|None}.
-
-    Bot logic only needs `score`; `breakdown` is for dry-run analysis.
-    On JSON decode failure returns {'score': 0, 'breakdown': None}.
-    """
+def _strip_wrappers(response_text):
     cleaned = re.sub(r'<think>.*?</think>', '', response_text, flags=re.DOTALL).strip()
-    cleaned = re.sub(r'//.*', '', cleaned)
     cleaned = re.sub(r'^```(?:json)?\s*', '', cleaned)
-    cleaned = re.sub(r'\s*```$', '', cleaned).strip()
+    return re.sub(r'\s*```$', '', cleaned).strip()
 
+
+def parse_evaluate_and_summarize(response_text):
+    """Parses the combined LLM response into {'score': float, 'breakdown': dict, 'summary': str}.
+
+    The score is the mean of all five dimensions — a 0 (e.g. pure party
+    politics) lowers the average rather than being excluded. Returns None when
+    the response is not valid JSON, so callers can distinguish "model failed"
+    from "article legitimately scored low".
+    """
+    cleaned = _strip_wrappers(response_text)
     try:
         obj = json.loads(cleaned)
     except json.JSONDecodeError:
         logger.error(f"Failed to decode JSON from response: {cleaned}")
-        return {"score": 0, "breakdown": None}
+        return None
+    if not isinstance(obj, dict):
+        logger.error(f"Expected JSON object, got {type(obj).__name__}: {cleaned}")
+        return None
 
     breakdown = {key: obj.get(key, 0) for key in _EVALUATION_KEYS}
-    non_zero = [v for v in breakdown.values() if v != 0]
-    avg = sum(non_zero) / len(non_zero) if non_zero else 0
-    return {"score": avg, "breakdown": breakdown}
+    score = sum(breakdown.values()) / len(_EVALUATION_KEYS)
+    summary = (obj.get("summary") or "").strip()
+    return {"score": score, "breakdown": breakdown, "summary": summary}

--- a/seen_cache.py
+++ b/seen_cache.py
@@ -1,0 +1,112 @@
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class SeenCache:
+    """Persistent URL → outcome cache that stops re-processing articles across cycles.
+
+    Articles that reach a verdict the bot can't act on (too old, page broken,
+    no content, repeatedly failing) are not saved to Supabase, so without this
+    cache they would be re-fetched — and re-embedded / re-evaluated, burning
+    free-tier quota — on every 10-minute cycle while they remain on the homepage.
+
+    Terminal statuses skip the URL forever (until pruned). Transient statuses
+    increment an attempt counter and become terminal after ``max_attempts``.
+    Entries are pruned once not seen for ``max_age_days`` (longer than the
+    homepage lifetime of any article).
+    """
+
+    TERMINAL_STATUSES = {"too_old", "no_content", "post_failed", "failed"}
+
+    def __init__(self, path="seen_cache.json", max_attempts=3, max_age_days=14):
+        self.path = Path(path)
+        self.max_attempts = max_attempts
+        self.max_age_days = max_age_days
+        self._entries = {}
+        self._dirty = False
+        self._load()
+
+    def _now(self):
+        return datetime.now(timezone.utc)
+
+    def _load(self):
+        if not self.path.exists():
+            return
+        try:
+            with self.path.open(encoding="utf-8") as f:
+                self._entries = json.load(f)
+        except (ValueError, OSError) as e:
+            logger.warning(f"[seen-cache] Could not load {self.path}: {e}. Starting empty.")
+            self._entries = {}
+        if self._prune():
+            self.flush()
+
+    def _prune(self):
+        cutoff = (self._now() - timedelta(days=self.max_age_days)).isoformat()
+        stale = [url for url, e in self._entries.items() if e.get("last_seen", "") < cutoff]
+        for url in stale:
+            del self._entries[url]
+        if stale:
+            logger.info(f"[seen-cache] Pruned {len(stale)} stale entries.")
+            self._dirty = True
+        return bool(stale)
+
+    def should_skip(self, url):
+        """True when the URL has a terminal status or exhausted its attempts.
+
+        Refreshes ``last_seen`` on hits so entries aren't pruned while the
+        article is still listed on the homepage (refresh is persisted on the
+        next ``flush()``).
+        """
+        entry = self._entries.get(url)
+        if entry is None:
+            return False
+        skip = (
+            entry["status"] in self.TERMINAL_STATUSES
+            or entry.get("attempts", 0) >= self.max_attempts
+        )
+        if skip:
+            entry["last_seen"] = self._now().isoformat()
+            self._dirty = True
+        return skip
+
+    def record_terminal(self, url, status):
+        """Mark a URL as permanently handled (skipped on every future cycle)."""
+        self._entries[url] = {
+            "status": status,
+            "attempts": self.max_attempts,
+            "last_seen": self._now().isoformat(),
+        }
+        self.flush()
+
+    def record_attempt(self, url, status):
+        """Count one failed attempt; the URL turns terminal after max_attempts.
+
+        Returns the attempt count so callers can log progress.
+        """
+        entry = self._entries.get(url) or {"attempts": 0}
+        entry["attempts"] = entry.get("attempts", 0) + 1
+        entry["status"] = status
+        entry["last_seen"] = self._now().isoformat()
+        self._entries[url] = entry
+        self.flush()
+        return entry["attempts"]
+
+    def flush(self):
+        self._prune()
+        tmp = self.path.with_suffix(".json.tmp")
+        try:
+            with tmp.open("w", encoding="utf-8") as f:
+                json.dump(self._entries, f, ensure_ascii=False, indent=1)
+            tmp.replace(self.path)
+            self._dirty = False
+        except OSError as e:
+            logger.error(f"[seen-cache] Failed to write {self.path}: {e}")
+
+    def flush_if_dirty(self):
+        if self._dirty:
+            self.flush()

--- a/tests/test_ai_services.py
+++ b/tests/test_ai_services.py
@@ -7,8 +7,13 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from ai.openai_service import OpenAIService
-from ai.gemini_service import GeminiService
-import response_parser
+from ai.gemini_service import GeminiService, GeminiRateLimitError
+
+_VALID_JSON = (
+    '{"expat_impact": 8, "event_weight": 7, "politics": 6, "timeliness": 9, '
+    '"practical_utility": 5, "summary": "Test summary. \U0001F603"}'
+)
+
 
 class TestOpenAIService(unittest.TestCase):
 
@@ -22,37 +27,38 @@ class TestOpenAIService(unittest.TestCase):
         return mock_resp
 
     @patch('ai.openai_service.requests.post')
-    def test_summarize_with_emojis(self, mock_post):
-        mock_post.return_value = self._mock_response("Test summary. 😃")
+    def test_evaluate_and_summarize(self, mock_post):
+        mock_post.return_value = self._mock_response(_VALID_JSON)
 
-        summary = self.service.summarize_with_emojis("Test article")
+        result = self.service.evaluate_and_summarize("Test article")
 
-        self.assertEqual(summary, "Test summary. 😃")
+        self.assertAlmostEqual(result["score"], 7.0)
+        self.assertEqual(result["breakdown"]["expat_impact"], 8)
+        self.assertEqual(result["breakdown"]["politics"], 6)
+        self.assertEqual(result["summary"], "Test summary. \U0001F603")
         mock_post.assert_called_once()
         messages = mock_post.call_args.kwargs['json']['messages']
         self.assertIn("Test article", messages[1]['content'])
 
     @patch('ai.openai_service.requests.post')
-    def test_evaluate_article(self, mock_post):
-        mock_post.return_value = self._mock_response(
-            '{"expat_impact": 8, "event_weight": 7, "politics": 6, "timeliness": 9, "practical_utility": 5}'
-        )
+    def test_evaluate_and_summarize_invalid_json(self, mock_post):
+        mock_post.return_value = self._mock_response("not json at all")
 
-        result = self.service.evaluate_article("Test article")
+        self.assertIsNone(self.service.evaluate_and_summarize("Test article"))
 
-        self.assertAlmostEqual(result["score"], 7.0)
-        self.assertEqual(result["breakdown"]["expat_impact"], 8)
-        self.assertEqual(result["breakdown"]["politics"], 6)
-        mock_post.assert_called_once()
 
 class TestGeminiService(unittest.TestCase):
 
     def setUp(self):
         self.service = GeminiService(api_key="test_key")
+        GeminiService._last_call_at = 0.0
+        GeminiService._use_legacy_schema = False
 
-    def _mock_response(self, text):
+    def _mock_response(self, text, status_code=200):
         mock_resp = MagicMock()
-        mock_resp.raise_for_status.return_value = None
+        mock_resp.status_code = status_code
+        mock_resp.ok = status_code < 400
+        mock_resp.text = text
         mock_resp.json.return_value = {
             "candidates": [{
                 "content": {"parts": [{"text": text}]},
@@ -62,28 +68,55 @@ class TestGeminiService(unittest.TestCase):
         return mock_resp
 
     @patch('ai.gemini_service.requests.post')
-    def test_summarize_with_emojis(self, mock_post):
-        mock_post.return_value = self._mock_response("Test summary. 😃")
+    def test_evaluate_and_summarize(self, mock_post):
+        mock_post.return_value = self._mock_response(_VALID_JSON)
 
-        summary = self.service.summarize_with_emojis("Test article")
-
-        self.assertEqual(summary, "Test summary. 😃")
-        mock_post.assert_called_once()
-        sent_text = mock_post.call_args.kwargs['json']['contents'][0]['parts'][0]['text']
-        self.assertIn("Test article", sent_text)
-
-    @patch('ai.gemini_service.requests.post')
-    def test_evaluate_article(self, mock_post):
-        mock_post.return_value = self._mock_response(
-            '{"expat_impact": 8, "event_weight": 7, "politics": 6, "timeliness": 9, "practical_utility": 5}'
-        )
-
-        result = self.service.evaluate_article("Test article")
+        result = self.service.evaluate_and_summarize("Test article")
 
         self.assertAlmostEqual(result["score"], 7.0)
         self.assertEqual(result["breakdown"]["expat_impact"], 8)
-        self.assertEqual(result["breakdown"]["politics"], 6)
+        self.assertEqual(result["summary"], "Test summary. \U0001F603")
         mock_post.assert_called_once()
+        body = mock_post.call_args.kwargs['json']
+        self.assertIn("Test article", body['contents'][0]['parts'][0]['text'])
+        # Primary path uses the standard-JSON-Schema field, schema unmodified.
+        config = body['generationConfig']
+        self.assertIn('responseJsonSchema', config)
+        self.assertIn('summary', config['responseJsonSchema']['properties'])
+        self.assertEqual(config['thinkingConfig']['thinkingBudget'], 0)
+
+    @patch('ai.gemini_service.time.sleep')
+    @patch('ai.gemini_service.requests.post')
+    def test_falls_back_to_legacy_schema_on_400(self, mock_post, _mock_sleep):
+        rejected = MagicMock()
+        rejected.status_code = 400
+        rejected.ok = False
+        rejected.text = 'Unknown name "responseJsonSchema" in generation_config'
+        mock_post.side_effect = [rejected, self._mock_response(_VALID_JSON)]
+
+        result = self.service.evaluate_and_summarize("Test article")
+
+        self.assertAlmostEqual(result["score"], 7.0)
+        self.assertEqual(mock_post.call_count, 2)
+        self.assertTrue(GeminiService._use_legacy_schema)
+        retry_config = mock_post.call_args.kwargs['json']['generationConfig']
+        self.assertNotIn('responseJsonSchema', retry_config)
+        # Legacy schema is sanitized to the OpenAPI subset with uppercase types.
+        self.assertEqual(retry_config['responseSchema']['type'], 'OBJECT')
+        self.assertNotIn('additionalProperties', retry_config['responseSchema'])
+
+    @patch('ai.gemini_service.requests.post')
+    def test_429_raises_rate_limit_error_with_retry_after(self, mock_post):
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+        resp_429.ok = False
+        resp_429.headers = {"Retry-After": "17"}
+        mock_post.return_value = resp_429
+
+        with self.assertRaises(GeminiRateLimitError) as ctx:
+            self.service.evaluate_and_summarize("Test article")
+        self.assertEqual(ctx.exception.retry_after, 17.0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ai_services.py
+++ b/tests/test_ai_services.py
@@ -15,72 +15,75 @@ class TestOpenAIService(unittest.TestCase):
     def setUp(self):
         self.service = OpenAIService()
 
-    @patch('openai.OpenAI')
-    def test_summarize_with_emojis(self, MockOpenAI):
-        mock_client = MockOpenAI.return_value
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Test summary. 😃"
-        mock_client.chat.completions.create.return_value = mock_response
+    def _mock_response(self, text):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"choices": [{"message": {"content": text}}]}
+        return mock_resp
 
-        self.service.client = mock_client
+    @patch('ai.openai_service.requests.post')
+    def test_summarize_with_emojis(self, mock_post):
+        mock_post.return_value = self._mock_response("Test summary. 😃")
+
         summary = self.service.summarize_with_emojis("Test article")
 
         self.assertEqual(summary, "Test summary. 😃")
-        mock_client.chat.completions.create.assert_called_once()
-        call_args = mock_client.chat.completions.create.call_args
-        self.assertIn("Test article", call_args.kwargs['messages'][1]['content'])
+        mock_post.assert_called_once()
+        messages = mock_post.call_args.kwargs['json']['messages']
+        self.assertIn("Test article", messages[1]['content'])
 
-    @patch('openai.OpenAI')
-    def test_evaluate_article(self, MockOpenAI):
-        mock_client = MockOpenAI.return_value
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '{"expat_impact": 8, "event_weight": 7, "politics": 6, "timeliness": 9, "practical_utility": 5}'
-        mock_client.chat.completions.create.return_value = mock_response
+    @patch('ai.openai_service.requests.post')
+    def test_evaluate_article(self, mock_post):
+        mock_post.return_value = self._mock_response(
+            '{"expat_impact": 8, "event_weight": 7, "politics": 6, "timeliness": 9, "practical_utility": 5}'
+        )
 
-        self.service.client = mock_client
-        score = self.service.evaluate_article("Test article")
+        result = self.service.evaluate_article("Test article")
 
-        self.assertAlmostEqual(score, 7.0)
-        mock_client.chat.completions.create.assert_called_once()
+        self.assertAlmostEqual(result["score"], 7.0)
+        self.assertEqual(result["breakdown"]["expat_impact"], 8)
+        self.assertEqual(result["breakdown"]["politics"], 6)
+        mock_post.assert_called_once()
 
 class TestGeminiService(unittest.TestCase):
 
     def setUp(self):
-        # Mock genai configure and GenerativeModel
-        self.patcher_configure = patch('google.generativeai.configure')
-        self.patcher_model = patch('google.generativeai.GenerativeModel')
-        self.mock_configure = self.patcher_configure.start()
-        self.mock_model = self.patcher_model.start()
-
         self.service = GeminiService(api_key="test_key")
 
-    def tearDown(self):
-        self.patcher_configure.stop()
-        self.patcher_model.stop()
+    def _mock_response(self, text):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "candidates": [{
+                "content": {"parts": [{"text": text}]},
+                "finishReason": "STOP",
+            }]
+        }
+        return mock_resp
 
-    def test_summarize_with_emojis(self):
-        mock_response = MagicMock()
-        mock_response.text = "Test summary. 😃"
-        self.service.model.generate_content.return_value = mock_response
+    @patch('ai.gemini_service.requests.post')
+    def test_summarize_with_emojis(self, mock_post):
+        mock_post.return_value = self._mock_response("Test summary. 😃")
 
         summary = self.service.summarize_with_emojis("Test article")
 
         self.assertEqual(summary, "Test summary. 😃")
-        self.service.model.generate_content.assert_called_once()
-        call_args = self.service.model.generate_content.call_args
-        self.assertIn("Test article", call_args[0][0])
+        mock_post.assert_called_once()
+        sent_text = mock_post.call_args.kwargs['json']['contents'][0]['parts'][0]['text']
+        self.assertIn("Test article", sent_text)
 
-    def test_evaluate_article(self):
-        mock_response = MagicMock()
-        mock_response.text = '{"expat_impact": 8, "event_weight": 7, "politics": 6, "timeliness": 9, "practical_utility": 5}'
-        self.service.model.generate_content.return_value = mock_response
+    @patch('ai.gemini_service.requests.post')
+    def test_evaluate_article(self, mock_post):
+        mock_post.return_value = self._mock_response(
+            '{"expat_impact": 8, "event_weight": 7, "politics": 6, "timeliness": 9, "practical_utility": 5}'
+        )
 
-        score = self.service.evaluate_article("Test article")
+        result = self.service.evaluate_article("Test article")
 
-        self.assertAlmostEqual(score, 7.0)
-        self.service.model.generate_content.assert_called_once()
+        self.assertAlmostEqual(result["score"], 7.0)
+        self.assertEqual(result["breakdown"]["expat_impact"], 8)
+        self.assertEqual(result["breakdown"]["politics"], 6)
+        mock_post.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import response_parser
+
+
+class TestParseEvaluateAndSummarize(unittest.TestCase):
+
+    def test_valid_response(self):
+        result = response_parser.parse_evaluate_and_summarize(
+            '{"expat_impact": 8, "event_weight": 7, "politics": 6, "timeliness": 9, '
+            '"practical_utility": 5, "summary": "Hello. \U0001F603"}'
+        )
+        self.assertAlmostEqual(result["score"], 7.0)
+        self.assertEqual(result["breakdown"]["timeliness"], 9)
+        self.assertEqual(result["summary"], "Hello. \U0001F603")
+
+    def test_politics_zero_lowers_average(self):
+        # A 0 must count against the score, not be excluded from the mean.
+        result = response_parser.parse_evaluate_and_summarize(
+            '{"expat_impact": 10, "event_weight": 10, "politics": 0, "timeliness": 10, '
+            '"practical_utility": 10, "summary": "s"}'
+        )
+        self.assertAlmostEqual(result["score"], 8.0)
+
+    def test_markdown_fences_and_think_tags_stripped(self):
+        result = response_parser.parse_evaluate_and_summarize(
+            '<think>internal musing</think>```json\n'
+            '{"expat_impact": 5, "event_weight": 5, "politics": 5, "timeliness": 5, '
+            '"practical_utility": 5, "summary": "s"}\n```'
+        )
+        self.assertAlmostEqual(result["score"], 5.0)
+
+    def test_invalid_json_returns_none(self):
+        self.assertIsNone(response_parser.parse_evaluate_and_summarize("garbage"))
+
+    def test_non_object_json_returns_none(self):
+        self.assertIsNone(response_parser.parse_evaluate_and_summarize("[1, 2, 3]"))
+
+    def test_missing_keys_default_to_zero(self):
+        result = response_parser.parse_evaluate_and_summarize('{"summary": "s"}')
+        self.assertAlmostEqual(result["score"], 0.0)
+        self.assertEqual(result["breakdown"]["expat_impact"], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_seen_cache.py
+++ b/tests/test_seen_cache.py
@@ -1,0 +1,76 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from seen_cache import SeenCache
+
+URL = "https://example.com/article-1"
+
+
+class TestSeenCache(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self._tmp.name) / "seen_cache.json"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _cache(self, **kwargs):
+        return SeenCache(path=self.path, **kwargs)
+
+    def test_unknown_url_not_skipped(self):
+        self.assertFalse(self._cache().should_skip(URL))
+
+    def test_terminal_status_skips(self):
+        cache = self._cache()
+        cache.record_terminal(URL, "too_old")
+        self.assertTrue(cache.should_skip(URL))
+
+    def test_attempts_become_terminal_after_max(self):
+        cache = self._cache(max_attempts=3)
+        for expected in (1, 2):
+            self.assertEqual(cache.record_attempt(URL, "fetch_failed"), expected)
+            self.assertFalse(cache.should_skip(URL))
+        self.assertEqual(cache.record_attempt(URL, "fetch_failed"), 3)
+        self.assertTrue(cache.should_skip(URL))
+
+    def test_persists_across_instances(self):
+        self._cache().record_terminal(URL, "no_content")
+        self.assertTrue(self._cache().should_skip(URL))
+
+    def test_prunes_stale_entries_on_load(self):
+        cache = self._cache()
+        cache.record_terminal(URL, "too_old")
+        old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        data[URL]["last_seen"] = old
+        self.path.write_text(json.dumps(data), encoding="utf-8")
+
+        self.assertFalse(self._cache().should_skip(URL))
+
+    def test_should_skip_refreshes_last_seen(self):
+        cache = self._cache()
+        cache.record_terminal(URL, "too_old")
+        old = (datetime.now(timezone.utc) - timedelta(days=13)).isoformat()
+        cache._entries[URL]["last_seen"] = old
+
+        self.assertTrue(cache.should_skip(URL))
+        self.assertGreater(cache._entries[URL]["last_seen"], old)
+        cache.flush_if_dirty()
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        self.assertGreater(data[URL]["last_seen"], old)
+
+    def test_corrupt_file_starts_empty(self):
+        self.path.write_text("{not valid json", encoding="utf-8")
+        self.assertFalse(self._cache().should_skip(URL))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -3,7 +3,7 @@ Similarity tests for DataService.
 
 Classes:
   TestCosineMath            — pure numpy, no API calls
-  TestCohereEmbedding       — real Cohere API (skipped without COHERE_API_KEY)
+  TestGeminiEmbedding       — real Gemini API (skipped without GEMINI_API_KEY)
   TestDataServiceSimilarity — real embeddings + mocked Supabase requests
 """
 
@@ -30,7 +30,7 @@ def _load_env():
 
 _load_env()
 
-COHERE_API_KEY = os.getenv('COHERE_API_KEY', '')
+GEMINI_API_KEY = os.getenv('GEMINI_API_KEY', '')
 
 _DUMMY_URL = 'https://dummy.supabase.co'
 _DUMMY_KEY = 'dummy-key'
@@ -43,7 +43,7 @@ def _make_service():
         supabase_url=_DUMMY_URL,
         supabase_key=_DUMMY_KEY,
         DISTANCE_THRESHOLD=_DISTANCE_THRESHOLD,
-        cohere_api_key=COHERE_API_KEY or 'dummy',
+        gemini_api_key=GEMINI_API_KEY or 'dummy',
     )
 
 
@@ -75,11 +75,11 @@ class TestCosineMath(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# 2. Real Cohere embedding API
+# 2. Real Gemini embedding API
 # ---------------------------------------------------------------------------
 
-@unittest.skipUnless(COHERE_API_KEY, 'COHERE_API_KEY must be set')
-class TestCohereEmbedding(unittest.TestCase):
+@unittest.skipUnless(GEMINI_API_KEY, 'GEMINI_API_KEY must be set')
+class TestGeminiEmbedding(unittest.TestCase):
 
     def setUp(self):
         self.svc = _make_service()
@@ -89,9 +89,9 @@ class TestCohereEmbedding(unittest.TestCase):
         self.assertIsInstance(emb, list)
         self.assertTrue(all(isinstance(x, float) for x in emb))
 
-    def test_embed_returns_1024_dimensions(self):
+    def test_embed_returns_nonempty_vector(self):
         emb = self.svc._embed('Local council approves new park in Málaga')
-        self.assertEqual(len(emb), 1024)
+        self.assertGreater(len(emb), 0)
 
     def test_same_text_cosine_is_one(self):
         text = 'Málaga airport reaches record passenger numbers'
@@ -128,7 +128,7 @@ class TestCohereEmbedding(unittest.TestCase):
 # 3. DataService.is_new_article — real embeddings, mocked Supabase
 # ---------------------------------------------------------------------------
 
-@unittest.skipUnless(COHERE_API_KEY, 'COHERE_API_KEY must be set')
+@unittest.skipUnless(GEMINI_API_KEY, 'GEMINI_API_KEY must be set')
 class TestDataServiceSimilarity(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_supabase_connection.py
+++ b/tests/test_supabase_connection.py
@@ -26,7 +26,7 @@ _load_env()
 
 SUPABASE_URL = os.getenv('SUPABASE_URL', '').rstrip('/')
 SUPABASE_KEY = os.getenv('SUPABASE_KEY', '')
-COHERE_API_KEY = os.getenv('COHERE_API_KEY', '')
+GEMINI_API_KEY = os.getenv('GEMINI_API_KEY', '')
 ARTICLES_ENDPOINT = f"{SUPABASE_URL}/rest/v1/articles"
 HEADERS = {
     "apikey": SUPABASE_KEY,
@@ -35,7 +35,7 @@ HEADERS = {
 }
 
 REQUIRED_COLUMNS = {"id", "title", "date"}
-_DUMMY_EMBEDDING = [0.1] * 1024   # matches Cohere embed-multilingual-v3.0 dimensions
+_DUMMY_EMBEDDING = [0.1] * 1024   # arbitrary fixture for jsonb round-trip; dimension is not Gemini-specific
 
 
 @unittest.skipUnless(SUPABASE_URL and SUPABASE_KEY, "SUPABASE_URL and SUPABASE_KEY must be set")
@@ -101,7 +101,7 @@ class TestSupabaseTableStructure(unittest.TestCase):
         self.assertEqual(resp.status_code, 200, f"'date' column missing: {resp.text}")
 
     def test_embedding_column_exists(self):
-        """embedding (jsonb) column must exist — required for Cohere cosine deduplication."""
+        """embedding (jsonb) column must exist — required for Gemini cosine deduplication."""
         resp = requests.get(ARTICLES_ENDPOINT, headers=HEADERS, params={"select": "embedding", "limit": "0"}, timeout=10)
         self.assertEqual(
             resp.status_code, 200,
@@ -272,11 +272,11 @@ class TestSupabaseCRUD(unittest.TestCase):
         self.assertNotIn(resp.status_code, (200, 201), "Duplicate UUID insert should be rejected by primary key constraint")
 
 
-@unittest.skipUnless(SUPABASE_URL and SUPABASE_KEY and COHERE_API_KEY,
-                     "SUPABASE_URL, SUPABASE_KEY, and COHERE_API_KEY must be set")
+@unittest.skipUnless(SUPABASE_URL and SUPABASE_KEY and GEMINI_API_KEY,
+                     "SUPABASE_URL, SUPABASE_KEY, and GEMINI_API_KEY must be set")
 class TestDataServiceDeduplication(unittest.TestCase):
     """
-    End-to-end deduplication tests using real Cohere embeddings and live Supabase.
+    End-to-end deduplication tests using real Gemini embeddings and live Supabase.
     Each test cleans up after itself.
     """
 
@@ -286,7 +286,7 @@ class TestDataServiceDeduplication(unittest.TestCase):
             supabase_url=SUPABASE_URL,
             supabase_key=SUPABASE_KEY,
             DISTANCE_THRESHOLD=0.15,
-            cohere_api_key=COHERE_API_KEY,
+            gemini_api_key=GEMINI_API_KEY,
         )
         self._inserted_ids = []
 


### PR DESCRIPTION
## Summary

Reworks the per-article pipeline around a **cheapest-first** ordering so free checks run before quota-limited API calls, and consolidates the AI step into a single LLM call per article.

## Key changes

- **Combined evaluate + summarize** — scoring (5 dimensions) and summary generation now happen in one LLM request per article instead of two, for both Gemini and OpenAI providers (`evaluate_and_summarize()`).
- **Persistent seen-cache** (`seen_cache.py`) — a JSON cache of terminal outcomes (`too_old`, `no_content`, `duplicate`, `post_failed`) and transient-failure counters, preventing unsaveable articles from being re-processed every cycle. Self-prunes after 14 days.
- **Gemini rate-limit handling** — call staggering via a min-interval lock, `GeminiRateLimitError` carrying the API-suggested retry delay, and `thinkingBudget: 0` to protect output tokens.
- **Improved fetch error handling** — `fetch_article()` returns specific status strings (`fetch_failed`, `too_old`) recorded before any API call is spent.
- **Migrated embeddings from Cohere to Gemini** for duplicate detection.
- **Dry-run logging** (`dry_run_logger.py`) — `--dry-run` writes per-article results to a timestamped JSON for comparing score distributions across prompt changes.

## Tests

Adds `tests/test_seen_cache.py` and `tests/test_response_parser.py`; updates AI-service and similarity tests for the combined call and Gemini embeddings.
